### PR TITLE
fix: cors sse, body limit, model prices, cheapest gap, limit trace, score precision

### DIFF
--- a/docs/service/routing-engine.md
+++ b/docs/service/routing-engine.md
@@ -53,7 +53,7 @@ No configuration options.
 
 **Type:** scoring
 
-Scores models by cost efficiency. The cheapest model gets `1.0`; others receive a proportional score (`minCost / theirCost`). Free models (e.g. Ollama) always get `1.0` and paid models are capped at `0.999`.
+Scores models by cost efficiency. The cheapest model gets `1.0`; others receive a proportional score (`minCost / theirCost`). Free models (e.g. Ollama) always get `1.0` and paid models are capped at `0.5` when free models coexist — ensuring a meaningful, visible gap between free and paid options.
 
 No configuration options.
 

--- a/packages/dashboard/src/components/TraceEntryRenderer.tsx
+++ b/packages/dashboard/src/components/TraceEntryRenderer.tsx
@@ -20,16 +20,16 @@ function ScoreBar({ value }: { value: number | null | undefined }) {
   // Sanitize: converti stringhe numeriche e gestisci valori invalidi
   const numValue = typeof value === 'string' ? parseFloat(value) : value;
   const validValue = typeof numValue === 'number' && !isNaN(numValue) ? numValue : null;
-  
+
   if (validValue == null) return <span style={{ fontSize: '0.68rem', color: 'var(--text-muted)' }}>—</span>;
-  const pct = Math.round(validValue * 100);
+  const pct = Math.floor(validValue * 100);
   const color = validValue >= 0.7 ? '#4ade80' : validValue >= 0.4 ? '#facc15' : '#f87171';
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
       <div style={{ width: 60, height: 5, background: 'var(--border)', borderRadius: 3, overflow: 'hidden' }}>
         <div style={{ width: `${pct}%`, height: '100%', background: color, borderRadius: 3 }} />
       </div>
-      <span style={{ fontSize: '0.68rem', color, fontVariantNumeric: 'tabular-nums', minWidth: 30 }}>{validValue.toFixed(2)}</span>
+      <span style={{ fontSize: '0.68rem', color, fontVariantNumeric: 'tabular-nums', minWidth: 30 }}>{validValue.toFixed(3)}</span>
     </div>
   );
 }
@@ -41,6 +41,7 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
   const isError        = e.message === 'model:error';
   const isThinking     = e.message === 'model:thinking';
   const isRecap        = e.message === 'router:recap';
+  const isIntake       = e.message === 'router:intake';
 
   const labelColor = isError ? 'var(--danger)' : isThinking ? '#a78bfa' : isModelPrompt ? '#c4b5fd' : isRecap ? '#34d399' : 'var(--accent)';
 
@@ -130,6 +131,37 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
                 {JSON.stringify(responseJSON, null, 2)}
               </pre>
             </details>
+          )}
+        </div>
+
+      ) : isIntake ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <details>
+            <summary style={{ fontSize: '0.62rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>details</summary>
+            <pre style={{ ...preStyle, margin: '4px 0 0' }}>{JSON.stringify({
+              model: e.details?.model,
+              messageCount: e.details?.messageCount,
+              projectId: e.details?.projectId,
+            }, null, 2)}</pre>
+          </details>
+          {(e.details?.excludedByLimits ?? []).length > 0 && (
+            <div>
+              <div style={{ fontSize: '0.6rem', color: '#f87171', fontWeight: 700, letterSpacing: '0.04em', marginBottom: 4 }}>EXCLUDED BY LIMITS</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                {(e.details.excludedByLimits as any[]).map((exc: any, i: number) => (
+                  <div key={i} style={{ background: 'rgba(239,68,68,0.07)', border: '1px solid rgba(239,68,68,0.25)', borderRadius: 'var(--radius-sm)', padding: '5px 10px' }}>
+                    <div style={{ fontSize: '0.68rem', color: '#f87171', fontWeight: 600, marginBottom: exc.violated?.length ? 4 : 0 }}>{exc.model}</div>
+                    {(exc.violated ?? []).map((v: any, j: number) => (
+                      <div key={j} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.62rem', color: 'var(--text-muted)' }}>
+                        <span style={{ color: '#fca5a5', fontWeight: 600 }}>{v.metric}</span>
+                        <span>{v.window}</span>
+                        <span style={{ marginLeft: 'auto', color: '#f87171' }}>{v.current} / {v.limit}</span>
+                      </div>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            </div>
           )}
         </div>
 

--- a/packages/dashboard/src/pages/ModelFormPage.tsx
+++ b/packages/dashboard/src/pages/ModelFormPage.tsx
@@ -262,6 +262,13 @@ export function ModelFormPage() {
       customId = model.id;
     }
 
+    // If prices are 0 (model was created without specifying them), fall back to preset values
+    const preset = providerPresets.find(m => m.id === formId);
+    const inputPrice  = model.cost.inputPerMillion  > 0 ? model.cost.inputPerMillion  : (preset?.input  ?? 0);
+    const outputPrice = model.cost.outputPerMillion > 0 ? model.cost.outputPerMillion : (preset?.output ?? 0);
+    const cachePrice  = model.cost.cachePerMillion  != null ? model.cost.cachePerMillion : (preset?.cache ?? null);
+    const ctxWindow   = model.contextWindow != null ? model.contextWindow : (preset?.contextWindow ?? null);
+
     setIsCustomModel(customModel);
     setErr(''); setShowToken(false);
 
@@ -272,10 +279,10 @@ export function ModelFormPage() {
       provider,
       endpoint: model.endpoint,
       apiKey: '',
-      inputPerMillion: String(model.cost.inputPerMillion),
-      outputPerMillion: String(model.cost.outputPerMillion),
-      cachePerMillion: model.cost.cachePerMillion != null ? String(model.cost.cachePerMillion) : '',
-      contextWindow: model.contextWindow != null ? String(model.contextWindow) : '',
+      inputPerMillion: String(inputPrice),
+      outputPerMillion: String(outputPrice),
+      cachePerMillion: cachePrice != null ? String(cachePrice) : '',
+      contextWindow: ctxWindow != null ? String(ctxWindow) : '',
     }));
 
     // Resolve limits: prefer new `limits`, fall back to legacy `globalThresholds`

--- a/packages/service/src/cost/budget.ts
+++ b/packages/service/src/cost/budget.ts
@@ -293,3 +293,16 @@ export async function isAllowed(
   return checkLimits(limits, relevant, now);
 }
 
+/**
+ * Returns the limits that are currently exceeded for a model in a project.
+ * Returns [] if the model is within all limits (i.e. it is allowed).
+ */
+export async function getViolatedLimits(
+  model: ModelConfig,
+  project: ProjectConfig,
+  token?: ProjectToken,
+): Promise<LimitSnapshot[]> {
+  const snapshots = await getLimitUsageSnapshot(model, project, token);
+  return snapshots.filter(s => s.remaining <= 0);
+}
+

--- a/packages/service/src/routes/anthropic.ts
+++ b/packages/service/src/routes/anthropic.ts
@@ -29,6 +29,12 @@ export const anthropicRoutes: FastifyPluginAsync = async (fastify) => {
     setTrace(traceId, []);
 
     reply.hijack();
+    const origin = request.headers.origin;
+    if (origin) {
+      reply.raw.setHeader('Access-Control-Allow-Origin', origin);
+      reply.raw.setHeader('Access-Control-Allow-Credentials', 'true');
+      reply.raw.setHeader('Access-Control-Expose-Headers', 'x-routerly-trace-id');
+    }
     reply.raw.setHeader('Content-Type', 'text/event-stream');
     reply.raw.setHeader('Cache-Control', 'no-cache');
     reply.raw.setHeader('Connection', 'keep-alive');
@@ -37,7 +43,6 @@ export const anthropicRoutes: FastifyPluginAsync = async (fastify) => {
 
     const emit = (entry: TraceEntry) => {
       appendTrace(traceId, [entry]);
-      reply.raw.write(`data: ${JSON.stringify({ type: 'trace', entry })}\n\n`);
     };
 
     // 1. Route request

--- a/packages/service/src/routes/openai.ts
+++ b/packages/service/src/routes/openai.ts
@@ -62,6 +62,12 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
     if (isStream) {
       // ── Streaming path: avvia SSE subito ──────────────────────────────────
       reply.hijack();
+      const origin = request.headers.origin;
+      if (origin) {
+        reply.raw.setHeader('Access-Control-Allow-Origin', origin);
+        reply.raw.setHeader('Access-Control-Allow-Credentials', 'true');
+        reply.raw.setHeader('Access-Control-Expose-Headers', 'x-routerly-trace-id');
+      }
       reply.raw.setHeader('Content-Type', 'text/event-stream');
       reply.raw.setHeader('Cache-Control', 'no-cache');
       reply.raw.setHeader('Connection', 'keep-alive');
@@ -70,7 +76,6 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
 
       const emit = (entry: TraceEntry) => {
         appendTrace(traceId, [entry]);
-        reply.raw.write(`data: ${JSON.stringify({ type: 'trace', entry })}\n\n`);
       };
 
       let routingResponse;
@@ -79,7 +84,8 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         request.log.error({ err }, 'Routing model failed');
-        reply.raw.write(`data: ${JSON.stringify({ type: 'error', message: `Routing model failed: ${msg}` })}\n\n`);
+        const errChunk = { id: `chatcmpl-${traceId}`, object: 'chat.completion.chunk', created: Math.floor(Date.now() / 1000), model: body.model ?? '', choices: [{ index: 0, delta: { content: `Routing failed: ${msg}` }, finish_reason: 'stop' }] };
+        reply.raw.write(`data: ${JSON.stringify(errChunk)}\n\n`);
         reply.raw.write('data: [DONE]\n\n');
         reply.raw.end();
         return;
@@ -87,8 +93,6 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
 
       const allModelsList = await readConfig('models');
       const sortedCandidates = [...routingResponse.models].sort((a: any, b: any) => b.weight - a.weight);
-
-      reply.raw.write(`data: ${JSON.stringify({ type: 'result', candidates: sortedCandidates })}\n\n`);
 
       for (const candidate of sortedCandidates) {
         const model = allModelsList.find((m: any) => m.id === candidate.model);
@@ -122,7 +126,6 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
           request.log.error({ err, modelId: model.id }, 'Streaming error mid-stream');
-          reply.raw.write(`data: ${JSON.stringify({ type: 'error', message: msg })}\n\n`);
           reply.raw.write('data: [DONE]\n\n');
         }
 
@@ -132,7 +135,8 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
 
       // Tutti i candidati esauriti
       emit({ panel: 'response', message: 'model:error', details: { error: 'All candidates unavailable or budget-exhausted' } });
-      reply.raw.write(`data: ${JSON.stringify({ type: 'error', message: 'All candidate models are unavailable or budget-exhausted.' })}\n\n`);
+      const errChunk = { id: `chatcmpl-${traceId}`, object: 'chat.completion.chunk', created: Math.floor(Date.now() / 1000), model: body.model ?? '', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] };
+      reply.raw.write(`data: ${JSON.stringify(errChunk)}\n\n`);
       reply.raw.write('data: [DONE]\n\n');
       reply.raw.end();
       return;
@@ -199,7 +203,14 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
       owned_by: m.provider,
     }));
 
-    return reply.send({ object: 'list', data });
+    const adaPlaceholder: ModelObject = {
+      id: 'routerly/ada',
+      object: 'model',
+      created: 0,
+      owned_by: 'routerly',
+    };
+
+    return reply.send({ object: 'list', data: [adaPlaceholder, ...data] });
   });
 
   // ─── GET /v1/models/:model ────────────────────────────────────────────────────

--- a/packages/service/src/routing/policies/cheapest.ts
+++ b/packages/service/src/routing/policies/cheapest.ts
@@ -27,15 +27,15 @@ export const cheapestPolicy: PolicyFn = async ({ candidates }) => {
   const minPaid   = paidCosts.length > 0 ? Math.min(...paidCosts) : 0;
 
   // Quando esistono modelli gratuiti, i modelli a pagamento vengono scalati
-  // al massimo a 0.999 così un modello a $0 supera sempre qualsiasi modello
-  // a pagamento, anche il più economico (che altrimenti otterrebbe 1.0).
-  const paidCeiling = hasFreeModel ? 0.999 : 1.0;
+  // al massimo a 0.5: il modello gratuito supera sempre i modelli a pagamento
+  // con un gap visibile e proporzionale (cheapest paid = 0.5, 2x più caro = 0.25...).
+  const paidCeiling = hasFreeModel ? 0.5 : 1.0;
 
   const routing = costs.map(({ id, avgCost }) => ({
     model: id,
     point: avgCost === 0
       ? 1.0                                       // modello gratuito → massimo assoluto
-      : paidCeiling * (minPaid / avgCost),         // rapporto proporzionale, < 1 se esiste un modello gratuito
+      : paidCeiling * (minPaid / avgCost),         // proporzionale tra paid; se esiste gratuito, max 0.5
     avgCostPerMillion: avgCost,
   }));
 

--- a/packages/service/src/routing/router.ts
+++ b/packages/service/src/routing/router.ts
@@ -1,6 +1,7 @@
 import type { ChatCompletionRequest, ModelConfig, ProjectConfig, ProjectToken, RoutingCandidate } from '@routerly/shared';
 import { readConfig } from '../config/loader.js';
-import { isAllowed } from '../cost/budget.js';
+import { isAllowed, getViolatedLimits } from '../cost/budget.js';
+import type { LimitSnapshot } from '../cost/budget.js';
 import type { CandidateModel } from './policies/types.js';
 import { contextPolicy } from './policies/context.js';
 import { cheapestPolicy } from './policies/cheapest.js';
@@ -77,14 +78,16 @@ export async function routeRequest(
   // Esclude i modelli che hanno già superato uno o più limiti prima di
   // coinvolgere qualunque policy, così alle policy arrivano solo candidati
   // ancora validi.
-  const excludedByLimits: string[] = [];
+  type LimitExclusion = { modelId: string; violated: LimitSnapshot[] };
+  const excludedByLimits: LimitExclusion[] = [];
   const validCandidates: CandidateModel[] = [];
 
   await Promise.all(
     candidates.map(async (c) => {
       const allowed = await isAllowed(c.model, project, token);
       if (!allowed) {
-        excludedByLimits.push(c.model.id);
+        const violated = await getViolatedLimits(c.model, project, token);
+        excludedByLimits.push({ modelId: c.model.id, violated });
       } else {
         validCandidates.push(c);
       }
@@ -92,7 +95,21 @@ export async function routeRequest(
   );
 
   if (excludedByLimits.length > 0) {
-    log?.info({ excluded: excludedByLimits }, 'routing: models excluded — limits already exceeded');
+    for (const exc of excludedByLimits) {
+      log?.info(
+        {
+          modelId: exc.modelId,
+          violated: exc.violated.map(v => ({
+            metric: v.metric,
+            window: v.window,
+            limit: v.value,
+            current: v.current,
+            remaining: v.remaining,
+          })),
+        },
+        'routing: model excluded — limit exceeded',
+      );
+    }
   }
 
   if (validCandidates.length === 0) {
@@ -104,6 +121,20 @@ export async function routeRequest(
     model: request.model,
     messageCount: request.messages?.length ?? 0,
     projectId: project.id,
+    ...(excludedByLimits.length > 0
+      ? {
+          excludedByLimits: excludedByLimits.map(e => ({
+            model: e.modelId,
+            violated: e.violated.map(v => ({
+              metric: v.metric,
+              window: v.window,
+              limit: v.value,
+              current: v.current,
+              remaining: v.remaining,
+            })),
+          })),
+        }
+      : {}),
   });
   emit?.(intakeEntry);
 

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -22,6 +22,7 @@ export async function buildServer() {
         ? { transport: { target: 'pino-pretty', options: { colorize: true } } }
         : {}),
     },
+    bodyLimit: 256 * 1024 * 1024, // 256 MB — support large files, vision, and 2M-token contexts
   });
 
   // ─── Plugins ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Changes

- **CORS on hijacked SSE streams** (`openai.ts`, `anthropic.ts`): after `reply.hijack()`, manually set CORS headers on `reply.raw` — `@fastify/cors` is bypassed after hijack, causing silent browser failures on streaming responses
- **Body limit 256MB** (`server.ts`): Fastify default is 1MB; raised to 256MB to support vision uploads and large context requests
- **Model price fallback on edit** (`ModelFormPage.tsx`): `editModel()` now substitutes preset prices when stored `inputPerMillion`/`outputPerMillion` are 0, preventing models from being treated as free by the cheapest policy
- **Cheapest policy gap** (`cheapest.ts`): `paidCeiling` changed from `0.999` to `0.5` when free models exist — ensures a meaningful visual and scoring gap between free ## Changes

- **CORS on hijacked SSE streams** (`openai.ts`, `anthropic.ts`): after `reply.hijack()`, manually set CORS headers on `reply.raw` — `@fastify/cors` is bypassed after hijack, causing silent browser failures on streaming responses
- **Bo)

- **CORS di- **Body limit 256MB** (`server.ts`): Fastify default is 1MB; raised to 256MB to support vision uploads and large context requests
- **Model price fallback on edit** (`ModelFormPage.tsx`): `editModel()` now substitutes preset pric e- **Model price fallback on edit** (`ModelFormPage.tsx`): `editModel()` now substitutes preset prices when stored `inputPerMillio c- **Cheapest policy gation to reflect new `0.5` ceiling