### PR TITLE
feat: add time-based filtering and pagination to usage page

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ Mix and match freely. A single project can span cloud and local models simultane
 
 ---
 
+## Benchmarks
+
+Independent benchmarks are published in the **[routerly-benchmark](https://github.com/Inebrio/routerly-benchmark)** repository.
+Reproducible tests measure routing latency overhead, cost savings across workloads, and failover behaviour under simulated provider outages.
+
+---
+
 ## Documentation
 
 Full documentation is available at **[https://docs.routerly.ai](https://docs.routerly.ai)**.

--- a/docs/concepts/routing.md
+++ b/docs/concepts/routing.md
@@ -64,6 +64,12 @@ Filters out models whose context window is smaller than the current request's es
 
 Uses a separate LLM call to decide which model to route to, based on request content. This policy is experimental and introduces an extra API call per request.
 
+**Config options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `thinking` | `boolean` | `false` | If `true` and the routing model supports extended thinking (e.g. Claude with thinking capability), the routing call uses it for more accurate decisions. **Warning:** this increases routing latency significantly. |
+
 **Use when:** you want dynamic model selection based on request semantics.
 
 ### `rate-limit`

--- a/docs/concepts/routing.md
+++ b/docs/concepts/routing.md
@@ -7,6 +7,10 @@ sidebar_position: 5
 
 Routerly's router selects which model to use for each request by running a configurable stack of **routing policies**. Policies are applied in priority order; each policy can score, filter, or directly pick a model from the candidate set.
 
+:::tip Benchmarks
+Reproducible routing benchmarks — latency overhead, cost savings, and failover behaviour — are published at **[github.com/Inebrio/routerly-benchmark](https://github.com/Inebrio/routerly-benchmark)**.
+:::
+
 ---
 
 ## How Routing Works

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -298,13 +298,16 @@ export interface UsageStats {
   byModel: Record<string, { calls: number; inputTokens: number; outputTokens: number; cachedInputTokens: number; cost: number; errors: number }>;
   timeline: [string, number][];
   records: Array<UsageRecord>;
+  pagination?: { page: number; pageSize: number; totalRecords: number; totalPages: number };
 }
 
-export const getUsage = (period = 'monthly', projectId?: string, from?: string, to?: string) => {
+export const getUsage = (period = 'monthly', projectId?: string, from?: string, to?: string, page?: number, pageSize?: number) => {
   const params = new URLSearchParams({ period });
   if (projectId) params.set('projectId', projectId);
   if (from) params.set('from', from);
   if (to)   params.set('to', to);
+  if (page != null) params.set('page', String(page));
+  if (pageSize != null) params.set('pageSize', String(pageSize));
   return request<UsageStats>(`/usage?${params.toString()}`);
 };
 

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -153,6 +153,7 @@ export interface PricingTier {
 
 export interface Model {
   id: string; name: string; provider: string; endpoint: string;
+  upstreamModelId?: string;
   cost: { inputPerMillion: number; outputPerMillion: number; cachePerMillion?: number; pricingTiers?: PricingTier[] };
   contextWindow?: number;
   limits?: Limit[];
@@ -162,7 +163,7 @@ export interface Model {
 export const getModels = () => request<Model[]>('/models');
 export const createModel = (data: {
   id: string; name?: string; provider: string; endpoint: string; apiKey?: string;
-  cloneFrom?: string;
+  cloneFrom?: string; upstreamModelId?: string;
   inputPerMillion: number; outputPerMillion: number;
   cachePerMillion?: number;
   contextWindow?: number;
@@ -172,6 +173,7 @@ export const createModel = (data: {
 export const updateModel = (id: string, data: {
   id?: string;
   name?: string; provider: string; endpoint: string; apiKey?: string;
+  upstreamModelId?: string;
   inputPerMillion: number; outputPerMillion: number;
   cachePerMillion?: number;
   contextWindow?: number;

--- a/packages/dashboard/src/components/DateRangePicker.tsx
+++ b/packages/dashboard/src/components/DateRangePicker.tsx
@@ -45,7 +45,7 @@ function addDays(d: Date, n: number) {
 function parseTimeFromISO(iso: string, defaultTime: string): string {
   if (!iso || iso.length <= 10) return defaultTime;
   const match = iso.match(/T(\d{2}:\d{2}:\d{2})/);
-  return match ? match[1] : defaultTime;
+  return match?.[1] ?? defaultTime;
 }
 
 /** Recent time-window presets (minutes / hours) — always use ISO datetime strings */

--- a/packages/dashboard/src/components/DateRangePicker.tsx
+++ b/packages/dashboard/src/components/DateRangePicker.tsx
@@ -2,8 +2,8 @@ import { useState, useRef, useEffect } from 'react';
 import { Calendar, ChevronDown, X, ChevronLeft, ChevronRight } from 'lucide-react';
 
 export interface DateRange {
-  from: string; // YYYY-MM-DD or ''
-  to:   string; // YYYY-MM-DD or ''
+  from: string; // ISO datetime string, YYYY-MM-DD, or ''
+  to:   string; // ISO datetime string, YYYY-MM-DD, or ''
   label: string;
 }
 
@@ -42,6 +42,53 @@ function addDays(d: Date, n: number) {
   return r;
 }
 
+function parseTimeFromISO(iso: string, defaultTime: string): string {
+  if (!iso || iso.length <= 10) return defaultTime;
+  const match = iso.match(/T(\d{2}:\d{2}:\d{2})/);
+  return match ? match[1] : defaultTime;
+}
+
+/** Recent time-window presets (minutes / hours) — always use ISO datetime strings */
+export const RECENT_PRESETS: { label: string; range: () => DateRange }[] = [
+  {
+    label: 'Ultimo minuto',
+    range: () => ({ from: new Date(Date.now() - 1 * 60_000).toISOString(), to: new Date().toISOString(), label: 'Ultimo minuto' }),
+  },
+  {
+    label: 'Ultimi 3 minuti',
+    range: () => ({ from: new Date(Date.now() - 3 * 60_000).toISOString(), to: new Date().toISOString(), label: 'Ultimi 3 minuti' }),
+  },
+  {
+    label: 'Ultimi 5 minuti',
+    range: () => ({ from: new Date(Date.now() - 5 * 60_000).toISOString(), to: new Date().toISOString(), label: 'Ultimi 5 minuti' }),
+  },
+  {
+    label: 'Ultimi 10 minuti',
+    range: () => ({ from: new Date(Date.now() - 10 * 60_000).toISOString(), to: new Date().toISOString(), label: 'Ultimi 10 minuti' }),
+  },
+  {
+    label: 'Ultimi 15 minuti',
+    range: () => ({ from: new Date(Date.now() - 15 * 60_000).toISOString(), to: new Date().toISOString(), label: 'Ultimi 15 minuti' }),
+  },
+  {
+    label: 'Ultimi 30 minuti',
+    range: () => ({ from: new Date(Date.now() - 30 * 60_000).toISOString(), to: new Date().toISOString(), label: 'Ultimi 30 minuti' }),
+  },
+  {
+    label: 'Ultima ora',
+    range: () => ({ from: new Date(Date.now() - 60 * 60_000).toISOString(), to: new Date().toISOString(), label: 'Ultima ora' }),
+  },
+  {
+    label: 'Ultime 6 ore',
+    range: () => ({ from: new Date(Date.now() - 6 * 60 * 60_000).toISOString(), to: new Date().toISOString(), label: 'Ultime 6 ore' }),
+  },
+  {
+    label: 'Ultime 12 ore',
+    range: () => ({ from: new Date(Date.now() - 12 * 60 * 60_000).toISOString(), to: new Date().toISOString(), label: 'Ultime 12 ore' }),
+  },
+];
+
+/** Day-level presets — use YYYY-MM-DD format */
 export const PRESETS: { label: string; range: () => DateRange }[] = [
   {
     label: 'Oggi',
@@ -111,20 +158,26 @@ export function DateRangePicker({ value, onChange }: Props) {
   const [pendingTo,   setPendingTo]   = useState(value.to);
   const [pickingEnd,  setPickingEnd]  = useState(false);
   const [hovered,     setHovered]     = useState('');
+  const [pendingFromTime, setPendingFromTime] = useState('00:00:00');
+  const [pendingToTime, setPendingToTime]     = useState('23:59:59');
 
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setPendingFrom(value.from);
-    setPendingTo(value.to);
+    setPendingFrom((value.from || '').slice(0, 10));
+    setPendingTo((value.to || '').slice(0, 10));
+    setPendingFromTime(parseTimeFromISO(value.from, '00:00:00'));
+    setPendingToTime(parseTimeFromISO(value.to, '23:59:59'));
     setPickingEnd(false);
   }, [value]);
 
   useEffect(() => {
     function onOutside(e: MouseEvent) {
       if (ref.current && !ref.current.contains(e.target as Node)) {
-        setPendingFrom(value.from);
-        setPendingTo(value.to);
+        setPendingFrom((value.from || '').slice(0, 10));
+        setPendingTo((value.to || '').slice(0, 10));
+        setPendingFromTime(parseTimeFromISO(value.from, '00:00:00'));
+        setPendingToTime(parseTimeFromISO(value.to, '23:59:59'));
         setPickingEnd(false);
         setHovered('');
         setOpen(false);
@@ -161,17 +214,35 @@ export function DateRangePicker({ value, onChange }: Props) {
   }
 
   function handleConfirm() {
-    const from  = pendingFrom;
-    const to    = pendingTo || pendingFrom;
-    const label = from ? (from === to ? from : `${from} — ${to}`) : 'Tutto il tempo';
+    const fromDate = pendingFrom;
+    const toDate   = pendingTo || pendingFrom;
+    const ft = pendingFromTime.length === 5 ? pendingFromTime + ':00' : pendingFromTime;
+    const tt = pendingToTime.length === 5 ? pendingToTime + ':00' : pendingToTime;
+    const from = fromDate ? `${fromDate}T${ft}` : '';
+    const to   = toDate   ? `${toDate}T${tt}`   : '';
+    const isDefaultTimes = ft === '00:00:00' && tt === '23:59:59';
+    let label: string;
+    if (!fromDate) {
+      label = 'Tutto il tempo';
+    } else if (fromDate === toDate && isDefaultTimes) {
+      label = fromDate;
+    } else if (fromDate === toDate) {
+      label = `${fromDate} ${ft.slice(0, 5)}\u2013${tt.slice(0, 5)}`;
+    } else if (isDefaultTimes) {
+      label = `${fromDate} — ${toDate}`;
+    } else {
+      label = `${fromDate} ${ft.slice(0, 5)} — ${toDate} ${tt.slice(0, 5)}`;
+    }
     onChange({ from, to, label });
     setOpen(false);
     setPickingEnd(false);
   }
 
   function handleCancel() {
-    setPendingFrom(value.from);
-    setPendingTo(value.to);
+    setPendingFrom((value.from || '').slice(0, 10));
+    setPendingTo((value.to || '').slice(0, 10));
+    setPendingFromTime(parseTimeFromISO(value.from, '00:00:00'));
+    setPendingToTime(parseTimeFromISO(value.to, '23:59:59'));
     setPickingEnd(false);
     setHovered('');
     setOpen(false);
@@ -226,9 +297,42 @@ export function DateRangePicker({ value, onChange }: Props) {
 
             {/* ── Preset list ── */}
             <div style={{
-              width: 170, borderRight: '1px solid var(--border)',
+              width: 180, borderRight: '1px solid var(--border)',
               padding: '8px 6px', display: 'flex', flexDirection: 'column', gap: 1,
+              overflowY: 'auto', maxHeight: 420,
             }}>
+              {/* Section: Recenti */}
+              <div style={{ fontSize: '0.65rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-muted)', padding: '6px 12px 2px' }}>
+                Recenti
+              </div>
+              {RECENT_PRESETS.map(p => {
+                const active = p.label === value.label;
+                return (
+                  <button
+                    key={p.label}
+                    onClick={() => handlePreset(p.range())}
+                    style={{
+                      background: active ? 'var(--accent, #6366f1)' : 'transparent',
+                      border: 'none', borderRadius: 6,
+                      padding: '7px 12px', textAlign: 'left',
+                      color: active ? '#fff' : 'var(--text-primary)',
+                      fontSize: '0.84rem', cursor: 'pointer',
+                      fontWeight: active ? 600 : 400,
+                      transition: 'background 0.1s',
+                    }}
+                    onMouseEnter={e => { if (!active) (e.currentTarget as HTMLButtonElement).style.background = 'var(--bg-elevated)'; }}
+                    onMouseLeave={e => { if (!active) (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
+                  >
+                    {p.label}
+                  </button>
+                );
+              })}
+              {/* Separator */}
+              <div style={{ height: 1, background: 'var(--border)', margin: '6px 12px' }} />
+              {/* Section: Intervalli */}
+              <div style={{ fontSize: '0.65rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-muted)', padding: '4px 12px 2px' }}>
+                Intervalli
+              </div>
               {PRESETS.map(p => {
                 const r = p.range();
                 const active = r.label === value.label && r.from === value.from && r.to === value.to;
@@ -355,6 +459,30 @@ export function DateRangePicker({ value, onChange }: Props) {
                     </div>
                   );
                 })}
+              </div>
+
+              {/* Time inputs */}
+              <div style={{ display: 'flex', gap: 16, alignItems: 'center', marginTop: 12 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, flex: 1 }}>
+                  <label style={{ fontSize: '0.78rem', color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>Da</label>
+                  <input type="time" step="1" value={pendingFromTime}
+                    onChange={e => { let t = e.target.value; if (t.length === 5) t += ':00'; setPendingFromTime(t || '00:00:00'); }}
+                    style={{
+                      background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 6,
+                      color: 'var(--text-primary)', padding: '4px 8px', fontSize: '0.82rem', flex: 1, colorScheme: 'dark',
+                    }}
+                  />
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, flex: 1 }}>
+                  <label style={{ fontSize: '0.78rem', color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>A</label>
+                  <input type="time" step="1" value={pendingToTime}
+                    onChange={e => { let t = e.target.value; if (t.length === 5) t += ':00'; setPendingToTime(t || '23:59:59'); }}
+                    style={{
+                      background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 6,
+                      color: 'var(--text-primary)', padding: '4px 8px', fontSize: '0.82rem', flex: 1, colorScheme: 'dark',
+                    }}
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/packages/dashboard/src/components/DateRangePicker.tsx
+++ b/packages/dashboard/src/components/DateRangePicker.tsx
@@ -305,6 +305,28 @@ export function DateRangePicker({ value, onChange }: Props) {
               <div style={{ fontSize: '0.65rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-muted)', padding: '6px 12px 2px' }}>
                 Recenti
               </div>
+              {/* "From now" — freezes 'from' to the clicked instant, open-ended 'to' */}
+              {(() => {
+                const active = value.label === 'From now';
+                return (
+                  <button
+                    onClick={() => handlePreset({ from: new Date().toISOString(), to: '', label: 'From now' })}
+                    style={{
+                      background: active ? 'var(--accent, #6366f1)' : 'transparent',
+                      border: 'none', borderRadius: 6,
+                      padding: '7px 12px', textAlign: 'left',
+                      color: active ? '#fff' : 'var(--text-primary)',
+                      fontSize: '0.84rem', cursor: 'pointer',
+                      fontWeight: active ? 600 : 400,
+                      transition: 'background 0.1s',
+                    }}
+                    onMouseEnter={e => { if (!active) (e.currentTarget as HTMLButtonElement).style.background = 'var(--bg-elevated)'; }}
+                    onMouseLeave={e => { if (!active) (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
+                  >
+                    From now
+                  </button>
+                );
+              })()}
               {RECENT_PRESETS.map(p => {
                 const active = p.label === value.label;
                 return (

--- a/packages/dashboard/src/components/MessageStatsCard.tsx
+++ b/packages/dashboard/src/components/MessageStatsCard.tsx
@@ -1,6 +1,6 @@
-import { Clock, Zap, FileText, AlertCircle, TrendingUp, type LucideIcon } from 'lucide-react';
+import { Clock, Zap, FileText, AlertCircle, TrendingUp, DollarSign, type LucideIcon } from 'lucide-react';
 import type { MessageStats } from '../utils/traceUtils';
-import { formatDuration, formatTokensPerSec, formatTokens } from '../utils/traceUtils';
+import { formatDuration, formatTokensPerSec, formatTokens, formatCost } from '../utils/traceUtils';
 
 interface MessageStatsProps {
   stats: MessageStats;
@@ -131,6 +131,54 @@ export function MessageStatsCard({ stats, turnNumber }: MessageStatsProps) {
             : '—'}
         />
       </div>
+
+      {/* Cost Breakdown */}
+      {stats.totalCostUsd != null && (
+        <div style={{
+          marginTop: 16,
+          paddingTop: 12,
+          borderTop: '1px solid var(--border)',
+        }}>
+          <div style={{ fontSize: '0.7rem', color: 'var(--text-muted)', marginBottom: 8, textTransform: 'uppercase', letterSpacing: '0.03em' }}>
+            Cost Breakdown
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '0.8rem' }}>
+              <span style={{ color: 'var(--text-secondary)' }}>
+                <DollarSign size={12} style={{ display: 'inline', marginRight: 4 }} />
+                Input ({stats.inputTokens?.toLocaleString() ?? '—'} tokens)
+              </span>
+              <span style={{ fontVariantNumeric: 'tabular-nums', color: 'var(--text-primary)', fontWeight: 500 }}>
+                {formatCost(stats.inputCostUsd)}
+              </span>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '0.8rem' }}>
+              <span style={{ color: 'var(--text-secondary)' }}>
+                <DollarSign size={12} style={{ display: 'inline', marginRight: 4 }} />
+                Output ({stats.outputTokens?.toLocaleString() ?? '—'} tokens)
+              </span>
+              <span style={{ fontVariantNumeric: 'tabular-nums', color: 'var(--text-primary)', fontWeight: 500 }}>
+                {formatCost(stats.outputCostUsd)}
+              </span>
+            </div>
+            <div style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginTop: 6,
+              paddingTop: 8,
+              borderTop: '1px dashed var(--border)',
+              fontSize: '0.875rem',
+              fontWeight: 600,
+            }}>
+              <span style={{ color: 'var(--text-primary)' }}>Total Cost</span>
+              <span style={{ fontVariantNumeric: 'tabular-nums', color: '#4ade80' }}>
+                {formatCost(stats.totalCostUsd)}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Cached Tokens */}
       {stats.cachedTokens != null && stats.cachedTokens > 0 && (

--- a/packages/dashboard/src/components/MessageStatsCard.tsx
+++ b/packages/dashboard/src/components/MessageStatsCard.tsx
@@ -1,0 +1,159 @@
+import { Clock, Zap, FileText, AlertCircle, TrendingUp, type LucideIcon } from 'lucide-react';
+import type { MessageStats } from '../utils/traceUtils';
+import { formatDuration, formatTokensPerSec, formatTokens } from '../utils/traceUtils';
+
+interface MessageStatsProps {
+  stats: MessageStats;
+  turnNumber: number;
+}
+
+function StatItem({ icon: Icon, label, value, color = 'var(--text-secondary)' }: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  color?: string;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <Icon size={14} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2, flex: 1, minWidth: 0 }}>
+        <span style={{ fontSize: '0.7rem', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.03em' }}>
+          {label}
+        </span>
+        <span style={{ fontSize: '0.875rem', color, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>
+          {value}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function ScoreBar({ value }: { value: number | null }) {
+  if (value == null) return <span style={{ fontSize: '0.875rem', color: 'var(--text-muted)' }}>—</span>;
+  
+  const pct = Math.floor(value * 100);
+  const color = value >= 0.7 ? '#4ade80' : value >= 0.4 ? '#facc15' : '#f87171';
+  
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div style={{ flex: 1, height: 8, background: 'var(--border)', borderRadius: 4, overflow: 'hidden' }}>
+        <div style={{ width: `${pct}%`, height: '100%', background: color, borderRadius: 4, transition: 'width 0.3s ease' }} />
+      </div>
+      <span style={{ fontSize: '0.875rem', color, fontWeight: 600, fontVariantNumeric: 'tabular-nums', minWidth: 48 }}>
+        {value.toFixed(3)}
+      </span>
+    </div>
+  );
+}
+
+export function MessageStatsCard({ stats, turnNumber }: MessageStatsProps) {
+  return (
+    <div style={{
+      background: 'var(--bg-elevated)',
+      border: stats.hasError ? '2px solid var(--danger)' : '1px solid var(--border)',
+      borderRadius: 8,
+      padding: 16,
+      marginBottom: 12,
+    }}>
+      {/* Header */}
+      <div style={{ 
+        display: 'flex', 
+        alignItems: 'center', 
+        justifyContent: 'space-between',
+        marginBottom: 12,
+        paddingBottom: 12,
+        borderBottom: '1px solid var(--border)',
+      }}>
+        <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)', fontWeight: 600 }}>
+          Turn #{turnNumber}
+        </span>
+        {stats.hasError && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.8rem', color: 'var(--danger)', fontWeight: 600 }}>
+            <AlertCircle size={14} />
+            ERROR
+          </div>
+        )}
+      </div>
+
+      {/* Model */}
+      {stats.selectedModel && (
+        <div style={{ marginBottom: 12 }}>
+          <div style={{ fontSize: '0.7rem', color: 'var(--text-muted)', marginBottom: 4, textTransform: 'uppercase', letterSpacing: '0.03em' }}>
+            Selected Model
+          </div>
+          <div style={{
+            background: 'var(--primary)',
+            color: 'white',
+            padding: '6px 12px',
+            borderRadius: 6,
+            fontSize: '0.875rem',
+            fontWeight: 600,
+            fontFamily: 'monospace',
+            display: 'inline-block',
+          }}>
+            {stats.selectedModel}
+          </div>
+        </div>
+      )}
+
+      {/* Router Score */}
+      {stats.routerScore != null && (
+        <div style={{ marginBottom: 12 }}>
+          <div style={{ fontSize: '0.7rem', color: 'var(--text-muted)', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.03em' }}>
+            Router Score
+          </div>
+          <ScoreBar value={stats.routerScore} />
+        </div>
+      )}
+
+      {/* Stats Grid */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginTop: 12 }}>
+        <StatItem
+          icon={Clock}
+          label="Latency"
+          value={formatDuration(stats.latencyMs)}
+        />
+        <StatItem
+          icon={Zap}
+          label="TTFT"
+          value={formatDuration(stats.ttftMs)}
+        />
+        <StatItem
+          icon={TrendingUp}
+          label="Speed"
+          value={formatTokensPerSec(stats.tokensPerSec)}
+        />
+        <StatItem
+          icon={FileText}
+          label="Tokens"
+          value={stats.inputTokens != null && stats.outputTokens != null
+            ? `${formatTokens(stats.inputTokens)} / ${formatTokens(stats.outputTokens)}`
+            : '—'}
+        />
+      </div>
+
+      {/* Cached Tokens */}
+      {stats.cachedTokens != null && stats.cachedTokens > 0 && (
+        <div style={{ marginTop: 12, fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
+          💾 Cached: {formatTokens(stats.cachedTokens)} tokens
+        </div>
+      )}
+
+      {/* Error Message */}
+      {stats.hasError && stats.errorMessage && (
+        <div style={{
+          marginTop: 12,
+          padding: 10,
+          background: 'rgba(239, 68, 68, 0.1)',
+          border: '1px solid rgba(239, 68, 68, 0.3)',
+          borderRadius: 6,
+          fontSize: '0.8rem',
+          color: 'var(--danger)',
+          fontFamily: 'monospace',
+        }}>
+          {stats.errorMessage}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/TraceEntryRenderer.tsx
+++ b/packages/dashboard/src/components/TraceEntryRenderer.tsx
@@ -53,7 +53,7 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
     background: 'var(--bg-surface)',
     border: isError ? '1px solid rgba(239,68,68,0.3)' : '1px solid var(--border)',
     borderRadius: 'var(--radius-sm)',
-    fontSize: '0.72rem', overflowX: 'auto',
+    fontSize: '0.85rem', overflowX: 'auto',
     color: isError ? 'var(--danger)' : 'var(--text-secondary)',
     whiteSpace: 'pre-wrap',
   };
@@ -62,7 +62,7 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
     <div style={{ marginBottom: 8 }}>
 
       {!isRecap && (
-        <div style={{ fontSize: '0.6rem', color: labelColor, marginBottom: 3, fontWeight: 700, letterSpacing: '0.04em' }}>
+        <div style={{ fontSize: '0.75rem', color: labelColor, marginBottom: 3, fontWeight: 700, letterSpacing: '0.04em' }}>
           {e.message}
           {isModelPrompt && (
             <span style={{ fontWeight: 400, marginLeft: 6, color: 'var(--text-muted)' }}>
@@ -74,7 +74,7 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
 
       {isModelPrompt ? (
         <details>
-          <summary style={{ fontSize: '0.62rem', color: '#c4b5fd', cursor: 'pointer', userSelect: 'none' }}>
+          <summary style={{ fontSize: '0.8rem', color: '#c4b5fd', cursor: 'pointer', userSelect: 'none' }}>
             {String(e.details.prompt ?? '').substring(0, 100)}{String(e.details.prompt ?? '').length > 100 ? '…' : ''}
           </summary>
           <pre style={{ ...preStyle, margin: '4px 0 0', background: 'rgba(99,102,241,0.08)', border: '1px solid rgba(99,102,241,0.3)', color: '#c4b5fd' }}>
@@ -84,7 +84,7 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
 
       ) : isThinking ? (
         <details>
-          <summary style={{ fontSize: '0.68rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>
+          <summary style={{ fontSize: '0.85rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>
             {String(e.details?.text ?? '').substring(0, 80)}
             {String(e.details?.text ?? '').length > 80 ? '\u2026' : ''}
           </summary>
@@ -97,14 +97,14 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
         <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
           {/* Metadati tecnici */}
           <details>
-            <summary style={{ fontSize: '0.62rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>technical details</summary>
+            <summary style={{ fontSize: '0.8rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>technical details</summary>
             <pre style={{ ...preStyle, margin: '4px 0 0' }}>{JSON.stringify(baseDetails, null, 2)}</pre>
           </details>
 
           {/* System prompt sempre espanso (solo chiamate routing) */}
           {systemPrompt != null && (
             <>
-              <div style={{ fontSize: '0.6rem', color: '#a5b4fc', fontWeight: 600, marginTop: 2 }}>system prompt</div>
+              <div style={{ fontSize: '0.75rem', color: '#a5b4fc', fontWeight: 600, marginTop: 2 }}>system prompt</div>
               <pre style={{ ...preStyle, background: 'rgba(99,102,241,0.08)', border: '1px solid rgba(99,102,241,0.25)', color: '#c4b5fd' }}>
                 {String(systemPrompt)}
               </pre>
@@ -114,7 +114,7 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
           {/* Response text (solo chiamate routing) */}
           {responseText != null && (
             <>
-              <div style={{ fontSize: '0.6rem', color: '#86efac', fontWeight: 600, marginTop: 2 }}>response text</div>
+              <div style={{ fontSize: '0.75rem', color: '#86efac', fontWeight: 600, marginTop: 2 }}>response text</div>
               <pre style={{ ...preStyle, background: 'rgba(34,197,94,0.07)', border: '1px solid rgba(34,197,94,0.25)', color: '#86efac' }}>
                 {String(responseText)}
               </pre>
@@ -124,7 +124,7 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
           {/* Full response JSON collassabile (solo chiamate routing) */}
           {responseJSON != null && (
             <details>
-              <summary style={{ fontSize: '0.68rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>
+              <summary style={{ fontSize: '0.85rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>
                 response JSON
               </summary>
               <pre style={{ ...preStyle, margin: '4px 0 0' }}>
@@ -137,7 +137,7 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
       ) : isIntake ? (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           <details>
-            <summary style={{ fontSize: '0.62rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>details</summary>
+            <summary style={{ fontSize: '0.8rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>details</summary>
             <pre style={{ ...preStyle, margin: '4px 0 0' }}>{JSON.stringify({
               model: e.details?.model,
               messageCount: e.details?.messageCount,
@@ -146,13 +146,13 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
           </details>
           {(e.details?.excludedByLimits ?? []).length > 0 && (
             <div>
-              <div style={{ fontSize: '0.6rem', color: '#f87171', fontWeight: 700, letterSpacing: '0.04em', marginBottom: 4 }}>EXCLUDED BY LIMITS</div>
+              <div style={{ fontSize: '0.75rem', color: '#f87171', fontWeight: 700, letterSpacing: '0.04em', marginBottom: 4 }}>EXCLUDED BY LIMITS</div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
                 {(e.details.excludedByLimits as any[]).map((exc: any, i: number) => (
                   <div key={i} style={{ background: 'rgba(239,68,68,0.07)', border: '1px solid rgba(239,68,68,0.25)', borderRadius: 'var(--radius-sm)', padding: '5px 10px' }}>
-                    <div style={{ fontSize: '0.68rem', color: '#f87171', fontWeight: 600, marginBottom: exc.violated?.length ? 4 : 0 }}>{exc.model}</div>
+                    <div style={{ fontSize: '0.85rem', color: '#f87171', fontWeight: 600, marginBottom: exc.violated?.length ? 4 : 0 }}>{exc.model}</div>
                     {(exc.violated ?? []).map((v: any, j: number) => (
-                      <div key={j} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.62rem', color: 'var(--text-muted)' }}>
+                      <div key={j} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.8rem', color: 'var(--text-muted)' }}>
                         <span style={{ color: '#fca5a5', fontWeight: 600 }}>{v.metric}</span>
                         <span>{v.window}</span>
                         <span style={{ marginLeft: 'auto', color: '#f87171' }}>{v.current} / {v.limit}</span>
@@ -170,12 +170,12 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
           {/* Final ranking */}
           {e.details?.final?.length > 0 ? (
             <>
-              <div style={{ fontSize: '0.6rem', color: '#34d399', fontWeight: 700, letterSpacing: '0.04em', marginBottom: 2 }}>FINAL RANKING</div>
+              <div style={{ fontSize: '0.8rem', color: '#34d399', fontWeight: 700, letterSpacing: '0.04em', marginBottom: 2 }}>FINAL RANKING</div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
                 {e.details.final.map((f: any) => (
                   <div key={f.rank} style={{ display: 'flex', alignItems: 'center', gap: 8, background: 'var(--bg-surface)', border: f.rank === 1 ? '1px solid rgba(52,211,153,0.35)' : '1px solid var(--border)', borderRadius: 'var(--radius-sm)', padding: '4px 10px' }}>
-                    <span style={{ fontSize: '0.65rem', color: f.rank === 1 ? '#34d399' : 'var(--text-muted)', fontWeight: f.rank === 1 ? 700 : 400, minWidth: 16 }}>#{f.rank}</span>
-                    <span style={{ fontSize: '0.65rem', color: 'var(--text-primary)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.model}</span>
+                    <span style={{ fontSize: '0.8rem', color: f.rank === 1 ? '#34d399' : 'var(--text-muted)', fontWeight: f.rank === 1 ? 700 : 400, minWidth: 16 }}>#{f.rank}</span>
+                    <span style={{ fontSize: '0.85rem', color: 'var(--text-primary)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.model}</span>
                     <ScoreBar value={f.score ?? f.weight} />
                   </div>
                 ))}
@@ -183,37 +183,37 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
             </>
           ) : (
             <>
-              <div style={{ fontSize: '0.6rem', color: '#34d399', fontWeight: 700, letterSpacing: '0.04em', marginBottom: 2 }}>FINAL RANKING</div>
-              <div style={{ fontSize: '0.68rem', color: 'var(--text-muted)', padding: '8px 10px', background: 'var(--bg-surface)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)' }}>
+              <div style={{ fontSize: '0.8rem', color: '#34d399', fontWeight: 700, letterSpacing: '0.04em', marginBottom: 2 }}>FINAL RANKING</div>
+              <div style={{ fontSize: '0.85rem', color: 'var(--text-muted)', padding: '8px 10px', background: 'var(--bg-surface)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)' }}>
                 No ranking data (record may be corrupted or from older version)
               </div>
             </>
           )}
           {/* Per-policy winner table */}
-          <div style={{ fontSize: '0.6rem', color: '#34d399', fontWeight: 700, letterSpacing: '0.04em', marginBottom: 2, marginTop: 16 }}>POLICY SCORES</div>
+          <div style={{ fontSize: '0.8rem', color: '#34d399', fontWeight: 700, letterSpacing: '0.04em', marginBottom: 2, marginTop: 16 }}>POLICY SCORES</div>
           {(e.details?.policies ?? []).length > 0 ? (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
               {e.details.policies.map((p: any, i: number) => (
                 <div key={i} style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', padding: '6px 10px' }}>
                   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: p.scores?.length > 1 ? 4 : 0 }}>
-                    <span style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--text-primary)', textTransform: 'capitalize' }}>
+                    <span style={{ fontSize: '0.875rem', fontWeight: 700, color: 'var(--text-primary)', textTransform: 'capitalize' }}>
                       {p.type === 'llm' ? 'AI Routing' : p.type === 'rate-limit' ? 'Rate Limit' : p.type === 'budget-remaining' ? 'Budget Remaining' : p.type}
                     </span>
-                    <span style={{ fontSize: '0.6rem', color: 'var(--text-muted)' }}>weight {p.weight?.toFixed(2)}</span>
+                    <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>weight {p.weight?.toFixed(2)}</span>
                   </div>
                   {p.winner && (
                   <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: p.scores?.length > 1 ? 4 : 0 }}>
-                    <span style={{ fontSize: '0.65rem', color: '#fbbf24', fontWeight: 600 }}>★ {p.winner.model}</span>
+                    <span style={{ fontSize: '0.85rem', color: '#fbbf24', fontWeight: 600 }}>★ {p.winner.model}</span>
                     <ScoreBar value={p.winner.point ?? p.winner.score} />
                   </div>
                 )}
                 {p.scores?.length > 1 && (
                   <details>
-                    <summary style={{ fontSize: '0.62rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>all scores</summary>
+                    <summary style={{ fontSize: '0.8rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>all scores</summary>
                     <div style={{ display: 'flex', flexDirection: 'column', gap: 3, marginTop: 4 }}>
                       {p.scores.map((s: any, j: number) => (
                         <div key={j} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                          <span style={{ fontSize: '0.62rem', color: 'var(--text-secondary)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.model}</span>
+                          <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.model}</span>
                           <ScoreBar value={s.point ?? s.score} />
                         </div>
                       ))}
@@ -224,7 +224,7 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
             ))}
             </div>
           ) : (
-            <div style={{ fontSize: '0.68rem', color: 'var(--text-muted)', padding: '8px 10px', background: 'var(--bg-surface)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)' }}>
+            <div style={{ fontSize: '0.85rem', color: 'var(--text-muted)', padding: '8px 10px', background: 'var(--bg-surface)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)' }}>
               No policy data (record may be corrupted or from older version)
             </div>
           )}
@@ -232,7 +232,7 @@ export function TraceEntryRenderer({ entry: e }: TraceEntryRendererProps) {
 
       ) : (
         <details>
-          <summary style={{ fontSize: '0.62rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>details</summary>
+          <summary style={{ fontSize: '0.8rem', color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none' }}>details</summary>
           <pre style={{ ...preStyle, margin: '4px 0 0' }}>{JSON.stringify(e.details, null, 2)}</pre>
         </details>
       )}

--- a/packages/dashboard/src/pages/ModelFormPage.tsx
+++ b/packages/dashboard/src/pages/ModelFormPage.tsx
@@ -114,6 +114,7 @@ const EMPTY_TIER: TierRow = {
 
 const EMPTY_FORM = {
   customId: '',
+  customProviderName: '',
   id: '',
   provider: 'openai' as Provider,
   endpoint: ENDPOINT_DEFAULTS.openai,
@@ -226,8 +227,8 @@ export function ModelFormPage() {
 
   function handleProviderChange(provider: Provider) {
     const firstModel = PROVIDER_MODELS[provider]?.[0];
-    setIsCustomModel(false);
-    setForm({ ...EMPTY_FORM, provider, endpoint: ENDPOINT_DEFAULTS[provider], id: firstModel?.id ?? '' });
+    setIsCustomModel(provider === 'custom');
+    setForm({ ...EMPTY_FORM, provider, endpoint: ENDPOINT_DEFAULTS[provider] ?? '', id: firstModel?.id ?? '' });
     setTierRows([]); setShowAdvanced(false);
     if (firstModel) applyPreset(provider, firstModel.id);
   }
@@ -252,8 +253,21 @@ export function ModelFormPage() {
     let formId = '';
     let customId = '';
     let customModel = true;
+    let customProviderName = '';
 
-    if (model.id.startsWith(prefix)) {
+    if (provider === 'custom') {
+      // For custom provider, the ID is stored as "{upstreamProvider}/{modelName}"
+      // or just "{modelName}" if no prefix was set.
+      if (model.id.includes('/')) {
+        const slashIdx = model.id.indexOf('/');
+        customProviderName = model.id.slice(0, slashIdx);
+        // Prefer the explicit upstreamModelId field; fall back to the part after the slash.
+        formId = model.upstreamModelId ?? model.id.slice(slashIdx + 1);
+      } else {
+        formId = model.upstreamModelId ?? model.id;
+      }
+      customModel = true;
+    } else if (model.id.startsWith(prefix)) {
       formId = model.id.slice(prefix.length);
       if (providerPresets.some(m => m.id === formId)) {
         customModel = false;
@@ -276,6 +290,7 @@ export function ModelFormPage() {
       ...f,
       id: formId,
       customId: customId,
+      customProviderName,
       provider,
       endpoint: model.endpoint,
       apiKey: '',
@@ -326,13 +341,19 @@ export function ModelFormPage() {
 
   function effectiveId(): string {
     if (form.customId.trim()) return form.customId.trim();
-    return generateId(form.provider, form.id, models.filter(m => m.id !== editingModelId).map(m => m.id));
+    const prefix = form.provider === 'custom' && form.customProviderName.trim()
+      ? form.customProviderName.trim()
+      : form.provider;
+    return generateId(prefix, form.id, models.filter(m => m.id !== editingModelId).map(m => m.id));
   }
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
     setErr(''); setSaving(true);
-    const finalId = form.customId.trim() || generateId(form.provider, form.id, models.filter(m => m.id !== editingModelId).map(m => m.id));
+    const idPrefix = form.provider === 'custom' && form.customProviderName.trim()
+      ? form.customProviderName.trim()
+      : form.provider;
+    const finalId = form.customId.trim() || generateId(idPrefix, form.id, models.filter(m => m.id !== editingModelId).map(m => m.id));
     if (!finalId) { setErr('Model ID required'); setSaving(false); return; }
     if (isCloning && models.some(m => m.id === finalId)) { setErr(`Model "${finalId}" already exists — set a different Custom ID`); setSaving(false); return; }
 
@@ -353,6 +374,8 @@ export function ModelFormPage() {
         endpoint: form.endpoint,
         ...(form.apiKey ? { apiKey: form.apiKey } : {}),
         ...(isCloning && cloneSourceId && !form.apiKey ? { cloneFrom: cloneSourceId } : {}),
+        // For custom provider, save the exact upstream model ID separately from the Routerly ID.
+        ...(form.provider === 'custom' && form.id.trim() ? { upstreamModelId: form.id.trim() } : {}),
         inputPerMillion: parseFloat(form.inputPerMillion) || 0,
         outputPerMillion: parseFloat(form.outputPerMillion) || 0,
         ...(form.cachePerMillion ? { cachePerMillion: parseFloat(form.cachePerMillion) } : {}),
@@ -379,7 +402,10 @@ export function ModelFormPage() {
 
   const providerModels = PROVIDER_MODELS[form.provider] ?? [];
   const selectedPreset = providerModels.find(m => m.id === form.id);
-  const autoId = form.id ? generateId(form.provider, form.id, models.filter(m => m.id !== editingModelId).map(m => m.id)) : '';
+  const autoIdPrefix = form.provider === 'custom' && form.customProviderName.trim()
+    ? form.customProviderName.trim()
+    : form.provider;
+  const autoId = form.id ? generateId(autoIdPrefix, form.id, models.filter(m => m.id !== editingModelId).map(m => m.id)) : '';
 
   if (loading) {
     return (
@@ -409,11 +435,12 @@ export function ModelFormPage() {
             <p className="section-desc">Unique identifier and provider settings for this model configuration.</p>
             <div className="form-group">
               <label className="form-label">
-                Custom ID <span style={{ color: 'var(--text-muted)', fontWeight: 400 }}>(optional — default: <code style={{ fontSize: '0.78rem' }}>{autoId || `${form.provider}/model`}</code>)</span>
+                Routerly ID <span style={{ color: 'var(--text-muted)', fontWeight: 400 }}>(optional — default: <code style={{ fontSize: '0.78rem' }}>{autoId || `${autoIdPrefix}/model`}</code>)</span>
               </label>
               <input className="form-input" value={form.customId} name="modelId" autoComplete="off"
                 onChange={e => setForm(f => ({ ...f, customId: e.target.value }))}
-                placeholder={autoId || `${form.provider}/model`} />
+                placeholder={autoId || `${autoIdPrefix}/model`} />
+              <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginTop: 4 }}>The identifier used when referencing this model in Routerly API calls.</div>
             </div>
 
             <div className="form-group">
@@ -424,24 +451,47 @@ export function ModelFormPage() {
               </select>
             </div>
 
-            <div className="form-group">
-              <label className="form-label">Model Preset</label>
-              {providerModels.length > 0 ? (
-                <select className="form-input" value={isCustomModel ? '__custom__' : form.id}
-                  onChange={e => handleModelChange(e.target.value)}>
-                  {providerModels.map(m => <option key={m.id} value={m.id}>{m.id}</option>)}
-                  <option value="__custom__">— custom model name —</option>
-                </select>
-              ) : null}
-              {(isCustomModel || providerModels.length === 0) && (
-                <input className="form-input" style={{ marginTop: providerModels.length > 0 ? 6 : 0 }}
-                  value={form.id} onChange={e => setForm(f => ({ ...f, id: e.target.value }))}
-                  placeholder="e.g. my-fine-tuned-model" required autoFocus />
-              )}
-              {!isCustomModel && selectedPreset?.notes && (
-                <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginTop: 4 }}>{selectedPreset.notes}</div>
-              )}
-            </div>
+            {form.provider === 'custom' ? (
+              <>
+                <div className="form-group">
+                  <label className="form-label">Provider <span style={{ color: 'var(--text-muted)', fontWeight: 400 }}>(upstream provider name)</span></label>
+                  <input className="form-input"
+                    value={form.customProviderName}
+                    onChange={e => setForm(f => ({ ...f, customProviderName: e.target.value }))}
+                    placeholder="e.g. deepseek, mistral, groq"
+                    required />
+                  <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginTop: 4 }}>Used as prefix for the Routerly ID (e.g. <code style={{ fontSize: '0.72rem' }}>deepseek/deepseek-r1</code>).</div>
+                </div>
+                <div className="form-group">
+                  <label className="form-label">Model <span style={{ color: 'var(--text-muted)', fontWeight: 400 }}>(upstream model ID)</span></label>
+                  <input className="form-input"
+                    value={form.id}
+                    onChange={e => setForm(f => ({ ...f, id: e.target.value }))}
+                    placeholder="e.g. deepseek-r1, mistral-large-latest"
+                    required />
+                  <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginTop: 4 }}>The model identifier sent to the upstream API endpoint.</div>
+                </div>
+              </>
+            ) : (
+              <div className="form-group">
+                <label className="form-label">Model Preset</label>
+                {providerModels.length > 0 ? (
+                  <select className="form-input" value={isCustomModel ? '__custom__' : form.id}
+                    onChange={e => handleModelChange(e.target.value)}>
+                    {providerModels.map(m => <option key={m.id} value={m.id}>{m.id}</option>)}
+                    <option value="__custom__">— custom model name —</option>
+                  </select>
+                ) : null}
+                {(isCustomModel || providerModels.length === 0) && (
+                  <input className="form-input" style={{ marginTop: providerModels.length > 0 ? 6 : 0 }}
+                    value={form.id} onChange={e => setForm(f => ({ ...f, id: e.target.value }))}
+                    placeholder="e.g. my-fine-tuned-model" required autoFocus />
+                )}
+                {!isCustomModel && selectedPreset?.notes && (
+                  <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginTop: 4 }}>{selectedPreset.notes}</div>
+                )}
+              </div>
+            )}
           </div>
 
           {/* ── Section: Connection ───────────────────────────── */}

--- a/packages/dashboard/src/pages/TestPage.tsx
+++ b/packages/dashboard/src/pages/TestPage.tsx
@@ -1,9 +1,11 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Send, Square, Paperclip, AlertCircle, Eye, EyeOff, CheckCircle2 } from 'lucide-react';
+import { Send, Square, Paperclip, AlertCircle, Eye, EyeOff, CheckCircle2, ChevronLeft, ChevronRight } from 'lucide-react';
 import { getProjects, type Project } from '../api';
 import { TraceEntryRenderer } from '../components/TraceEntryRenderer';
+import { MessageStatsCard } from '../components/MessageStatsCard';
+import { extractMessageStats } from '../utils/traceUtils';
 
 interface Message {
   role: 'user' | 'assistant' | 'system';
@@ -27,13 +29,11 @@ export function TestPage() {
 
   const [showKey, setShowKey] = useState(false);
   const [debugTraceHistory, setDebugTraceHistory] = useState<(any[] | null)[]>([]);
+  const [showDebugSidebar, setShowDebugSidebar] = useState(true);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const routerReqPanelEndRef = useRef<HTMLDivElement>(null);
-  const routerResPanelEndRef = useRef<HTMLDivElement>(null);
-  const reqPanelEndRef = useRef<HTMLDivElement>(null);
-  const resPanelEndRef = useRef<HTMLDivElement>(null);
+  const debugPanelEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     getProjects().then(setProjects).catch(console.error);
@@ -49,31 +49,8 @@ export function TestPage() {
     return { matchedProject: null, matchedToken: null };
   }, [apiKey, projects]);
 
-  const routerRequestHistory = useMemo(() =>
-    debugTraceHistory.map(trace =>
-      trace ? (trace as any[]).filter(t => t.panel === 'router-request') : null
-    ), [debugTraceHistory]);
-
-  const routerResponseHistory = useMemo(() =>
-    debugTraceHistory.map(trace =>
-      trace ? (trace as any[]).filter(t => t.panel === 'router-response') : null
-    ), [debugTraceHistory]);
-
-  const requestHistory = useMemo(() =>
-    debugTraceHistory.map(trace =>
-      trace ? (trace as any[]).filter(t => t.panel === 'request') : null
-    ), [debugTraceHistory]);
-
-  const responseHistory = useMemo(() =>
-    debugTraceHistory.map(trace =>
-      trace ? (trace as any[]).filter(t => t.panel === 'response') : null
-    ), [debugTraceHistory]);
-
   useEffect(() => { messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [messages]);
-  useEffect(() => { routerReqPanelEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [routerRequestHistory]);
-  useEffect(() => { routerResPanelEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [routerResponseHistory]);
-  useEffect(() => { reqPanelEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [requestHistory]);
-  useEffect(() => { resPanelEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [responseHistory]);
+  useEffect(() => { debugPanelEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [debugTraceHistory]);
 
   async function handleSend() {
     if ((!input.trim() && !attachedImage) || !apiKey || loading) return;
@@ -441,97 +418,105 @@ export function TestPage() {
           </div>
 
           {/* ── Right Column: Debug Sidebar ── */}
-          <div className="card" style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', padding: 0 }}>
-            <div style={{ padding: '12px 20px', borderBottom: '1px solid var(--border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <h3 style={{ margin: 0, fontSize: '0.9rem', fontWeight: 600 }}>Debug Log</h3>
-              {debugTraceHistory.length > 0 && (
-                <button
-                  onClick={() => setDebugTraceHistory([])}
-                  style={{ fontSize: '0.7rem', color: 'var(--text-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 6px' }}
-                >
-                  Clear
-                </button>
-              )}
+          {showDebugSidebar && (
+            <div className="card" style={{ width: 420, display: 'flex', flexDirection: 'column', overflow: 'hidden', padding: 0 }}>
+              <div style={{ padding: '12px 20px', borderBottom: '1px solid var(--border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <h3 style={{ margin: 0, fontSize: '0.9rem', fontWeight: 600 }}>Debug</h3>
+                <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                  {debugTraceHistory.length > 0 && (
+                    <button
+                      onClick={() => setDebugTraceHistory([])}
+                      style={{ fontSize: '0.7rem', color: 'var(--text-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 6px' }}
+                    >
+                      Clear
+                    </button>
+                  )}
+                  <button
+                    onClick={() => setShowDebugSidebar(false)}
+                    className="btn-icon"
+                    style={{ padding: 4 }}
+                    title="Hide debug sidebar"
+                  >
+                    <ChevronRight size={16} />
+                  </button>
+                </div>
+              </div>
+
+              <div style={{ flex: 1, overflowY: 'auto', padding: 16, background: 'var(--bg-base)' }}>
+                {debugTraceHistory.length === 0 ? (
+                  <div style={{ textAlign: 'center', padding: '40px 20px', color: 'var(--text-muted)' }}>
+                    <p style={{ margin: 0, fontSize: '0.85rem' }}>No debug data yet.</p>
+                    <p style={{ margin: '8px 0 0', fontSize: '0.75rem' }}>Send a message to see routing and model details.</p>
+                  </div>
+                ) : (
+                  debugTraceHistory.map((traces, i) => {
+                    if (!traces) return null;
+                    const stats = extractMessageStats(traces);
+                    return (
+                      <div key={i} style={{ marginBottom: 16 }}>
+                        <MessageStatsCard stats={stats} turnNumber={i + 1} />
+                        
+                        {/* Technical Details - Collapsible */}
+                        <details style={{ marginTop: 8 }}>
+                          <summary style={{
+                            cursor: 'pointer',
+                            fontSize: '0.8rem',
+                            color: 'var(--text-muted)',
+                            padding: '8px 12px',
+                            background: 'var(--bg-elevated)',
+                            border: '1px solid var(--border)',
+                            borderRadius: 6,
+                            userSelect: 'none',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 6,
+                          }}>
+                            🔧 Technical Details
+                          </summary>
+                          <div style={{
+                            marginTop: 8,
+                            padding: 12,
+                            background: 'var(--bg-surface)',
+                            border: '1px solid var(--border)',
+                            borderRadius: 6,
+                            fontSize: '0.85rem',
+                          }}>
+                            {traces.map((entry, j) => (
+                              <div key={j} style={{ marginBottom: j < traces.length - 1 ? 12 : 0 }}>
+                                <TraceEntryRenderer entry={entry} />
+                              </div>
+                            ))}
+                          </div>
+                        </details>
+                      </div>
+                    );
+                  })
+                )}
+                <div ref={debugPanelEndRef} />
+              </div>
             </div>
+          )}
 
-            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-
-              {/* Panel: Router Request */}
-              <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', borderBottom: '1px solid var(--border)' }}>
-                <div style={{ padding: '5px 12px', background: 'var(--bg-surface)', borderLeft: '3px solid #5A90F8', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
-                  <span style={{ fontSize: '0.68rem', color: 'var(--text-muted)', textTransform: 'uppercase', fontWeight: 600, letterSpacing: '0.05em' }}>Router Request</span>
-                </div>
-                <div style={{ flex: 1, overflowY: 'auto', padding: '8px 12px', background: 'var(--bg-base)', display: 'flex', flexDirection: 'column', gap: 8 }}>
-                  {debugTraceHistory.length === 0 ? (
-                    <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>No request sent yet.</span>
-                  ) : routerRequestHistory.map((entries, i) => (
-                    <div key={i}>
-                      <div style={{ fontSize: '0.65rem', color: 'var(--text-muted)', marginBottom: 3 }}>#{i + 1} {loading && i === debugTraceHistory.length - 1 && '⏳'}</div>
-                      {entries?.map((e: any, j: number) => <TraceEntryRenderer key={j} entry={e} />)}
-                    </div>
-                  ))}
-                  <div ref={routerReqPanelEndRef} />
-                </div>
-              </div>
-
-              {/* Panel: Router Response */}
-              <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', borderBottom: '1px solid var(--border)' }}>
-                <div style={{ padding: '5px 12px', background: 'var(--bg-surface)', borderLeft: '3px solid #A78BFA', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
-                  <span style={{ fontSize: '0.68rem', color: 'var(--text-muted)', textTransform: 'uppercase', fontWeight: 600, letterSpacing: '0.05em' }}>Router Response</span>
-                </div>
-                <div style={{ flex: 1, overflowY: 'auto', padding: '8px 12px', background: 'var(--bg-base)', display: 'flex', flexDirection: 'column', gap: 8 }}>
-                  {debugTraceHistory.length === 0 ? (
-                    <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>No request sent yet.</span>
-                  ) : routerResponseHistory.map((entries, i) => (
-                    <div key={i}>
-                      <div style={{ fontSize: '0.65rem', color: 'var(--text-muted)', marginBottom: 3 }}>#{i + 1} {loading && i === debugTraceHistory.length - 1 && '⏳'}</div>
-                      {entries?.map((e: any, j: number) => <TraceEntryRenderer key={j} entry={e} />)}
-                    </div>
-                  ))}
-                  <div ref={routerResPanelEndRef} />
-                </div>
-              </div>
-
-              {/* Panel: Request */}
-              <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', borderBottom: '1px solid var(--border)' }}>
-                <div style={{ padding: '5px 12px', background: 'var(--bg-surface)', borderLeft: '3px solid #10B981', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
-                  <span style={{ fontSize: '0.68rem', color: 'var(--text-muted)', textTransform: 'uppercase', fontWeight: 600, letterSpacing: '0.05em' }}>Request</span>
-                </div>
-                <div style={{ flex: 1, overflowY: 'auto', padding: '8px 12px', background: 'var(--bg-base)', display: 'flex', flexDirection: 'column', gap: 8 }}>
-                  {debugTraceHistory.length === 0 ? (
-                    <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>No request sent yet.</span>
-                  ) : requestHistory.map((entries, i) => (
-                    <div key={i}>
-                      <div style={{ fontSize: '0.65rem', color: 'var(--text-muted)', marginBottom: 3 }}>#{i + 1} {loading && i === debugTraceHistory.length - 1 && '⏳'}</div>
-                      {entries?.length === 0 && <span style={{ fontSize: '0.72rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>No model calls (routing only)</span>}
-                      {entries?.map((e: any, j: number) => <TraceEntryRenderer key={j} entry={e} />)}
-                    </div>
-                  ))}
-                  <div ref={reqPanelEndRef} />
-                </div>
-              </div>
-
-              {/* Panel: Response */}
-              <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
-                <div style={{ padding: '5px 12px', background: 'var(--bg-surface)', borderLeft: '3px solid #F59E0B', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
-                  <span style={{ fontSize: '0.68rem', color: 'var(--text-muted)', textTransform: 'uppercase', fontWeight: 600, letterSpacing: '0.05em' }}>Response</span>
-                </div>
-                <div style={{ flex: 1, overflowY: 'auto', padding: '8px 12px', background: 'var(--bg-base)', display: 'flex', flexDirection: 'column', gap: 8 }}>
-                  {debugTraceHistory.length === 0 ? (
-                    <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>No request sent yet.</span>
-                  ) : responseHistory.map((entries, i) => (
-                    <div key={i}>
-                      <div style={{ fontSize: '0.65rem', color: 'var(--text-muted)', marginBottom: 3 }}>#{i + 1} {loading && i === debugTraceHistory.length - 1 && '⏳'}</div>
-                      {entries?.length === 0 && <span style={{ fontSize: '0.72rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>No model calls (routing only)</span>}
-                      {entries?.map((e: any, j: number) => <TraceEntryRenderer key={j} entry={e} />)}
-                    </div>
-                  ))}
-                  <div ref={resPanelEndRef} />
-                </div>
-              </div>
-
-            </div>
-          </div>
+          {/* Toggle button when sidebar is collapsed */}
+          {!showDebugSidebar && (
+            <button
+              onClick={() => setShowDebugSidebar(true)}
+              className="btn-icon"
+              style={{
+                position: 'fixed',
+                right: 24,
+                top: '50%',
+                transform: 'translateY(-50%)',
+                padding: 8,
+                background: 'var(--bg-elevated)',
+                border: '1px solid var(--border)',
+                boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+              }}
+              title="Show debug sidebar"
+            >
+              <ChevronLeft size={20} />
+            </button>
+          )}
 
       </div>
     </div>

--- a/packages/dashboard/src/pages/UsagePage.tsx
+++ b/packages/dashboard/src/pages/UsagePage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getUsage, getProjects, type UsageStats, type Project } from '../api';
 import { MultiSelect } from '../components/MultiSelect';
-import { DateRangePicker, PRESETS, type DateRange } from '../components/DateRangePicker';
+import { DateRangePicker, PRESETS, RECENT_PRESETS, type DateRange } from '../components/DateRangePicker';
 import { useFilterState } from '../hooks/useFilterState';
 
 function FilterLabel({ children }: { children: React.ReactNode }) {
@@ -26,6 +26,8 @@ export function UsagePage() {
   const [lastUpdated, setLastUpdated]   = useState<Date | null>(null);
   const [pollInterval, setPollInterval] = useFilterState<number>({ key: 'usage-filters-pollInterval', defaultValue: 30_000 });
   const [refreshing, setRefreshing]     = useState(false);
+  const [page, setPage]                 = useState(1);
+  const [pageSize]                      = useState(50);
   const navigate = useNavigate();
 
   const POLL_OPTIONS: { label: string; value: number }[] = [
@@ -41,12 +43,16 @@ export function UsagePage() {
   // or re-apply stale relative presets (e.g. "Questo mese" saved on a previous day).
   useEffect(() => {
     const today = new Date().toISOString().slice(0, 10);
+    // Check if this is a recent (minutes/hours) preset — those are always recalculated on fetch
+    const isRecentPreset = RECENT_PRESETS.some(p => p.label === dateRange.label);
+    if (isRecentPreset) return; // will be recalculated by fetchStats
+
     if (!dateRange.from && !dateRange.to) {
       // First visit: default to this month
       const now = new Date();
       const from = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
       setDateRange({ from, to: today, label: 'Questo mese' });
-    } else if (dateRange.to && dateRange.to < today) {
+    } else if (dateRange.to && dateRange.to.slice(0, 10) < today) {
       // Stale "to" date — if this was a relative preset, recompute it
       const preset = PRESETS.find(p => p.label === dateRange.label);
       if (preset) setDateRange(preset.range());
@@ -58,15 +64,24 @@ export function UsagePage() {
   }, []);
 
   const fetchStats = useCallback(() => {
-    const period = dateRange.from || dateRange.to ? 'custom' : 'all';
-    return getUsage(period, undefined, dateRange.from || undefined, dateRange.to || undefined)
+    // For recent (minutes/hours) presets, recalculate the range on every fetch
+    let from = dateRange.from || undefined;
+    let to = dateRange.to || undefined;
+    const recentPreset = RECENT_PRESETS.find(p => p.label === dateRange.label);
+    if (recentPreset) {
+      const fresh = recentPreset.range();
+      from = fresh.from;
+      to = fresh.to;
+    }
+    const period = from || to ? 'custom' : 'all';
+    return getUsage(period, undefined, from, to, page, pageSize)
       .then(data => { setStats(data); setLastUpdated(new Date()); setFetchError(null); })
       .catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         setFetchError(msg);
         console.error('Failed to load usage stats:', msg);
       });
-  }, [dateRange]);
+  }, [dateRange, page, pageSize]);
 
   const handleRefreshNow = useCallback(() => {
     setRefreshing(true);
@@ -80,6 +95,9 @@ export function UsagePage() {
     const id = setInterval(fetchStats, pollInterval);
     return () => clearInterval(id);
   }, [fetchStats, pollInterval]);
+
+  // Reset page when filters change
+  useEffect(() => { setPage(1); }, [dateRange, projectIds, modelIds, callTypeFilter, outcomeFilter]);
 
   // Available model options — derived from all records in the current period
   const modelOptions = useMemo(() => {
@@ -287,7 +305,9 @@ export function UsagePage() {
             <>
               <h3 style={{ fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-secondary)', textTransform: 'uppercase', letterSpacing: '0.05em', margin: '0 0 12px' }}>
                 Recent Calls
-                <span style={{ fontWeight: 400, marginLeft: 8, color: 'var(--text-muted)' }}>({filteredRecords.length})</span>
+                <span style={{ fontWeight: 400, marginLeft: 8, color: 'var(--text-muted)' }}>
+                  ({stats.pagination ? `${filteredRecords.length} / ${stats.pagination.totalRecords}` : filteredRecords.length})
+                </span>
               </h3>
 
               {filteredRecords.length === 0 ? (
@@ -295,6 +315,7 @@ export function UsagePage() {
                   <p>{stats.records.length === 0 ? 'No usage records for this period.' : 'No records match the active filters.'}</p>
                 </div>
               ) : (
+                <>
                 <div className="table-wrap">
                   <table>
                     <thead>
@@ -347,6 +368,36 @@ export function UsagePage() {
                     </tbody>
                   </table>
                 </div>
+
+                {/* Pagination controls */}
+                {stats.pagination && stats.pagination.totalPages > 1 && (
+                  <div style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 12,
+                    marginTop: 16, padding: '10px 0',
+                  }}>
+                    <button
+                      className="btn btn-sm btn-secondary"
+                      disabled={page <= 1}
+                      onClick={() => setPage(p => Math.max(1, p - 1))}
+                    >
+                      ← Precedente
+                    </button>
+                    <span style={{ fontSize: '0.82rem', color: 'var(--text-secondary)' }}>
+                      Pagina {stats.pagination.page} di {stats.pagination.totalPages}
+                      <span style={{ color: 'var(--text-muted)', marginLeft: 8 }}>
+                        ({stats.pagination.totalRecords} record totali)
+                      </span>
+                    </span>
+                    <button
+                      className="btn btn-sm btn-secondary"
+                      disabled={page >= stats.pagination.totalPages}
+                      onClick={() => setPage(p => p + 1)}
+                    >
+                      Successiva →
+                    </button>
+                  </div>
+                )}
+                </>
               )}
             </>
           </>

--- a/packages/dashboard/src/pages/project/ProjectLogsTab.tsx
+++ b/packages/dashboard/src/pages/project/ProjectLogsTab.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { getUsage, type UsageStats, type UsageRecord } from '../../api';
-import { DateRangePicker, type DateRange } from '../../components/DateRangePicker';
+import { DateRangePicker, RECENT_PRESETS, type DateRange } from '../../components/DateRangePicker';
 import { MultiSelect } from '../../components/MultiSelect';
 import { useFilterState } from '../../hooks/useFilterState';
 
@@ -29,6 +29,8 @@ export function ProjectLogsTab() {
   const [lastUpdated, setLastUpdated]       = useState<Date | null>(null);
   const [pollInterval, setPollInterval]     = useFilterState<number>({ key: `project-${projectId}-filters-pollInterval`, defaultValue: 30_000 });
   const [refreshing, setRefreshing]         = useState(false);
+  const [page, setPage]                     = useState(1);
+  const [pageSize]                          = useState(50);
 
   const POLL_OPTIONS: { label: string; value: number }[] = [
     { label: 'Off',  value: 0 },
@@ -54,11 +56,20 @@ export function ProjectLogsTab() {
 
   const fetchStats = useCallback(() => {
     if (!projectId) return Promise.resolve();
-    const period = dateRange.from || dateRange.to ? 'custom' : 'all';
-    return getUsage(period, projectId, dateRange.from || undefined, dateRange.to || undefined)
+    // For recent (minutes/hours) presets, recalculate the range on every fetch
+    let from = dateRange.from || undefined;
+    let to = dateRange.to || undefined;
+    const recentPreset = RECENT_PRESETS.find(p => p.label === dateRange.label);
+    if (recentPreset) {
+      const fresh = recentPreset.range();
+      from = fresh.from;
+      to = fresh.to;
+    }
+    const period = from || to ? 'custom' : 'all';
+    return getUsage(period, projectId, from, to, page, pageSize)
       .then(data => { setStats(data); setLastUpdated(new Date()); })
       .catch(console.error);
-  }, [projectId, dateRange]);
+  }, [projectId, dateRange, page, pageSize]);
 
   const handleRefreshNow = useCallback(() => {
     setRefreshing(true);
@@ -72,6 +83,9 @@ export function ProjectLogsTab() {
     const id = setInterval(fetchStats, pollInterval);
     return () => clearInterval(id);
   }, [fetchStats, pollInterval]);
+
+  // Reset page when filters change
+  useEffect(() => { setPage(1); }, [dateRange, modelIds, callTypeFilter, outcomeFilter]);
 
   const modelOptions = useMemo(() => {
     if (!stats) return [];
@@ -244,7 +258,7 @@ export function ProjectLogsTab() {
           }}>
             Request Logs
             <span style={{ fontWeight: 400, marginLeft: 8, color: 'var(--text-muted)' }}>
-              ({filteredRecords.length})
+              ({stats.pagination ? `${filteredRecords.length} / ${stats.pagination.totalRecords}` : filteredRecords.length})
             </span>
           </h3>
 
@@ -256,6 +270,7 @@ export function ProjectLogsTab() {
               </p>
             </div>
           ) : (
+            <>
             <div className="table-wrap">
               <table>
                 <thead>
@@ -313,6 +328,36 @@ export function ProjectLogsTab() {
                 </tbody>
               </table>
             </div>
+
+            {/* Pagination controls */}
+            {stats.pagination && stats.pagination.totalPages > 1 && (
+              <div style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 12,
+                marginTop: 16, padding: '10px 0',
+              }}>
+                <button
+                  className="btn btn-sm btn-secondary"
+                  disabled={page <= 1}
+                  onClick={() => setPage(p => Math.max(1, p - 1))}
+                >
+                  ← Precedente
+                </button>
+                <span style={{ fontSize: '0.82rem', color: 'var(--text-secondary)' }}>
+                  Pagina {stats.pagination.page} di {stats.pagination.totalPages}
+                  <span style={{ color: 'var(--text-muted)', marginLeft: 8 }}>
+                    ({stats.pagination.totalRecords} record totali)
+                  </span>
+                </span>
+                <button
+                  className="btn btn-sm btn-secondary"
+                  disabled={page >= stats.pagination.totalPages}
+                  onClick={() => setPage(p => p + 1)}
+                >
+                  Successiva →
+                </button>
+              </div>
+            )}
+            </>
           )}
         </>
       )}

--- a/packages/dashboard/src/pages/project/ProjectRoutingTab.tsx
+++ b/packages/dashboard/src/pages/project/ProjectRoutingTab.tsx
@@ -368,6 +368,7 @@ export function ProjectRoutingTab() {
                             const usedIds = new Set(getLlmModelIds(policy).filter((_, i) => i !== mIdx));
                             const opts = availableModels
                               .filter(m => !usedIds.has(m.id))
+                              .sort((a, b) => a.id.localeCompare(b.id))
                               .map(m => ({ value: m.id, label: m.id }));
                             return (
                               <div
@@ -431,7 +432,10 @@ export function ProjectRoutingTab() {
                           <input
                             type="checkbox"
                             checked={policy.config?.autoRouting ?? true}
-                            onChange={(e) => updatePolicyConfig(idx, { autoRouting: e.target.checked })}
+                            onChange={(e) => {
+                              const checked = e.target.checked;
+                              updatePolicyConfig(idx, { autoRouting: checked, ...(checked ? { additionalPromptInfo: undefined } : {}) });
+                            }}
                             style={{ width: 14, height: 14, accentColor: 'var(--primary)', cursor: 'pointer' }}
                           />
                           Auto Routing
@@ -573,7 +577,7 @@ export function ProjectRoutingTab() {
                                   value={policy.config?.maxUserMessageChars ?? ''}
                                   onChange={e => {
                                     const v = e.target.value.replace(/[^0-9]/g, '');
-                                    updatePolicyConfig(idx, { maxUserMessageChars: v === '' ? undefined : Math.max(100, Number(v)) });
+                                    updatePolicyConfig(idx, { maxUserMessageChars: v === '' ? undefined : Number(v) });
                                   }}
                                   onMouseDown={e => e.stopPropagation()}
                                 />
@@ -682,18 +686,15 @@ export function ProjectRoutingTab() {
                 <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 12 }}>
                   <div className="form-group" style={{ margin: 0 }}>
                     <label style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginBottom: 4, display: 'block' }}>Endpoint Model</label>
-                    <select
-                      className="form-input"
+                    <SearchableSelect
                       value={item.modelId}
-                      onChange={e => updateTargetModel(idx, 'modelId', e.target.value)}
-                      required
-                      style={{ padding: '6px 10px', fontSize: '0.9rem' }}
-                    >
-                      <option value="" disabled>Select model</option>
-                      {availableModels
+                      onChange={v => updateTargetModel(idx, 'modelId', v)}
+                      placeholder="Select model"
+                      options={availableModels
                         .filter(m => m.id === item.modelId || !getUsedTargetModelIds(idx).has(m.id))
-                        .map(m => <option key={m.id} value={m.id}>{m.id}</option>)}
-                    </select>
+                        .sort((a, b) => a.id.localeCompare(b.id))
+                        .map(m => ({ value: m.id, label: m.id }))}
+                    />
                   </div>
 
                   {showPromptInput && (

--- a/packages/dashboard/src/pages/project/ProjectRoutingTab.tsx
+++ b/packages/dashboard/src/pages/project/ProjectRoutingTab.tsx
@@ -37,6 +37,9 @@ export function ProjectRoutingTab() {
   const [policies, setPolicies] = useState<PolicyItem[]>([]);
   const [targetModels, setTargetModels] = useState<TargetModel[]>([]);
 
+  // Advanced section open state per policy index
+  const [advancedOpen, setAdvancedOpen] = useState<Set<number>>(new Set());
+
   // Drag state
   const [draggedTargetIdx, setDraggedTargetIdx] = useState<number | null>(null);
   const [draggedPolicyIdx, setDraggedPolicyIdx] = useState<number | null>(null);
@@ -454,33 +457,134 @@ export function ProjectRoutingTab() {
                       </div>
 
                       <div style={{ borderTop: '1px solid var(--border)', paddingTop: 10 }}>
-                        <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: '0.85rem', fontWeight: 500 }}>
-                          <input
-                            type="checkbox"
-                            checked={policy.config?.memory ?? false}
-                            onChange={(e) => updatePolicyConfig(idx, { memory: e.target.checked })}
-                            style={{ width: 14, height: 14, accentColor: 'var(--primary)', cursor: 'pointer' }}
-                          />
-                          Memory
-                        </label>
-                        <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: 4, marginLeft: 22, lineHeight: 1.4, marginBottom: (policy.config?.memory ?? false) ? 8 : 12 }}>
-                          If enabled, the last N messages from the conversation history are included in the routing prompt to give the AI router additional context.
-                        </p>
-                        {(policy.config?.memory ?? false) && (
-                          <div style={{ marginLeft: 22, marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
-                            <label style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', whiteSpace: 'nowrap' }}>Previous messages</label>
-                            <input
-                              type="number"
-                              min={1}
-                              max={50}
-                              className="form-input"
-                              style={{ width: 70, padding: '4px 8px', fontSize: '0.8rem' }}
-                              value={policy.config?.memoryCount ?? 5}
-                              onChange={e => updatePolicyConfig(idx, { memoryCount: Math.max(1, Number(e.target.value)) })}
-                              onMouseDown={e => e.stopPropagation()}
-                            />
+                        <details
+                          open={advancedOpen.has(idx)}
+                          onToggle={(e) => {
+                            const open = (e.currentTarget as HTMLDetailsElement).open;
+                            setAdvancedOpen(prev => {
+                              const next = new Set(prev);
+                              open ? next.add(idx) : next.delete(idx);
+                              return next;
+                            });
+                          }}
+                        >
+                          <summary style={{ fontSize: '0.85rem', fontWeight: 500, cursor: 'pointer', userSelect: 'none', color: 'var(--text-secondary)', listStyle: 'none', display: 'flex', alignItems: 'center', gap: 6 }}>
+                            <span style={{ fontSize: '0.7rem', display: 'inline-block', transform: advancedOpen.has(idx) ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.15s ease' }}>▶</span> Advanced
+                          </summary>
+                          <div style={{ marginTop: 10, display: 'flex', flexDirection: 'column', gap: 0 }}>
+
+                            <div style={{ paddingBottom: 10 }}>
+                              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: '0.85rem', fontWeight: 500 }}>
+                                <input
+                                  type="checkbox"
+                                  checked={policy.config?.memory ?? false}
+                                  onChange={(e) => updatePolicyConfig(idx, { memory: e.target.checked })}
+                                  style={{ width: 14, height: 14, accentColor: 'var(--primary)', cursor: 'pointer' }}
+                                />
+                                Memory
+                              </label>
+                              <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: 4, marginLeft: 22, lineHeight: 1.4, marginBottom: (policy.config?.memory ?? false) ? 8 : 0 }}>
+                                If enabled, the last N messages from the conversation history are included in the routing prompt to give the AI router additional context.
+                              </p>
+                              {(policy.config?.memory ?? false) && (
+                                <div style={{ marginLeft: 22, marginTop: 6, display: 'flex', alignItems: 'center', gap: 8 }}>
+                                  <label style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', whiteSpace: 'nowrap' }}>Previous messages</label>
+                                  <input
+                                    type="number"
+                                    min={1}
+                                    max={50}
+                                    className="form-input"
+                                    style={{ width: 70, padding: '4px 8px', fontSize: '0.8rem' }}
+                                    value={policy.config?.memoryCount ?? 5}
+                                    onChange={e => updatePolicyConfig(idx, { memoryCount: Math.max(1, Number(e.target.value)) })}
+                                    onMouseDown={e => e.stopPropagation()}
+                                  />
+                                </div>
+                              )}
+                            </div>
+
+                            <div style={{ borderTop: '1px solid var(--border)', paddingTop: 10, paddingBottom: 10 }}>
+                              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: '0.85rem', fontWeight: 500 }}>
+                                <input
+                                  type="checkbox"
+                                  checked={policy.config?.thinking ?? false}
+                                  onChange={(e) => updatePolicyConfig(idx, { thinking: e.target.checked })}
+                                  style={{ width: 14, height: 14, accentColor: 'var(--primary)', cursor: 'pointer' }}
+                                />
+                                Thinking
+                              </label>
+                              <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: 4, marginLeft: 22, lineHeight: 1.4, marginBottom: 0 }}>
+                                If enabled and the routing model supports it, extended thinking is used for more accurate routing decisions. This increases latency significantly.
+                              </p>
+                            </div>
+
+                            <div style={{ borderTop: '1px solid var(--border)', paddingTop: 10, paddingBottom: 10 }}>
+                              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: '0.85rem', fontWeight: 500 }}>
+                                <input
+                                  type="checkbox"
+                                  checked={policy.config?.includeReason ?? false}
+                                  onChange={(e) => updatePolicyConfig(idx, { includeReason: e.target.checked })}
+                                  style={{ width: 14, height: 14, accentColor: 'var(--primary)', cursor: 'pointer' }}
+                                />
+                                Include Reason
+                              </label>
+                              <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: 4, marginLeft: 22, lineHeight: 1.4, marginBottom: 0 }}>
+                                If enabled, the routing model adds a brief explanation for each score. Useful for debugging but increases output tokens.
+                              </p>
+                            </div>
+
+                            <div style={{ borderTop: '1px solid var(--border)', paddingTop: 10, paddingBottom: 10 }}>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                                <label style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', whiteSpace: 'nowrap', minWidth: 160 }}>Max completion tokens</label>
+                                <input
+                                  type="text"
+                                  inputMode="numeric"
+                                  pattern="[0-9]*"
+                                  className="form-input"
+                                  style={{ width: 80, padding: '4px 8px', fontSize: '0.8rem' }}
+                                  placeholder="auto"
+                                  value={policy.config?.maxCompletionTokens ?? ''}
+                                  onChange={e => {
+                                    const v = e.target.value.replace(/[^0-9]/g, '');
+                                    updatePolicyConfig(idx, { maxCompletionTokens: v === '' ? undefined : Number(v) });
+                                  }}
+                                  onBlur={e => {
+                                    const v = e.target.value.replace(/[^0-9]/g, '');
+                                    if (v !== '' && Number(v) < 50) updatePolicyConfig(idx, { maxCompletionTokens: 50 });
+                                  }}
+                                  onMouseDown={e => e.stopPropagation()}
+                                />
+                              </div>
+                              <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: 4, marginBottom: 0, lineHeight: 1.4 }}>
+                                Limits the routing model output tokens. Leave empty to use the provider default.
+                              </p>
+                            </div>
+
+                            <div style={{ borderTop: '1px solid var(--border)', paddingTop: 10 }}>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                                <label style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', whiteSpace: 'nowrap', minWidth: 160 }}>Max prompt chars</label>
+                                <input
+                                  type="text"
+                                  inputMode="numeric"
+                                  pattern="[0-9]*"
+                                  className="form-input"
+                                  style={{ width: 80, padding: '4px 8px', fontSize: '0.8rem' }}
+                                  placeholder="auto"
+                                  value={policy.config?.maxUserMessageChars ?? ''}
+                                  onChange={e => {
+                                    const v = e.target.value.replace(/[^0-9]/g, '');
+                                    updatePolicyConfig(idx, { maxUserMessageChars: v === '' ? undefined : Math.max(100, Number(v)) });
+                                  }}
+                                  onMouseDown={e => e.stopPropagation()}
+                                />
+                              </div>
+                              <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: 4, marginBottom: 0, lineHeight: 1.4 }}>
+                                Truncates the routing prompt after this many characters. Leave empty for no limit.
+                              </p>
+                            </div>
+
                           </div>
-                        )}
+                        </details>
                       </div>
 
                     </div>

--- a/packages/dashboard/src/utils/traceUtils.ts
+++ b/packages/dashboard/src/utils/traceUtils.ts
@@ -1,0 +1,87 @@
+/**
+ * Utilities for extracting stats and metadata from trace entries
+ */
+
+interface TraceEntry {
+  message: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  details?: any;
+}
+
+export interface MessageStats {
+  selectedModel: string | null;
+  routerScore: number | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cachedTokens: number | null;
+  latencyMs: number | null;
+  ttftMs: number | null;
+  tokensPerSec: number | null;
+  hasError: boolean;
+  errorMessage?: string;
+}
+
+/**
+ * Extract statistics from trace entries.
+ * Note: details field is intentionally typed as any since it contains dynamic SSE data.
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+export function extractMessageStats(traces: TraceEntry[]): MessageStats {
+  const stats: MessageStats = {
+    selectedModel: null,
+    routerScore: null,
+    inputTokens: null,
+    outputTokens: null,
+    cachedTokens: null,
+    latencyMs: null,
+    ttftMs: null,
+    tokensPerSec: null,
+    hasError: false,
+  };
+
+  if (!traces || traces.length === 0) return stats;
+
+  // Extract from router:recap
+  const recap = traces.find((e) => e.message === 'router:recap');
+  if (recap?.details?.final?.[0]) {
+    stats.selectedModel = recap.details.final[0].model;
+    stats.routerScore = recap.details.final[0].score ?? recap.details.final[0].weight ?? null;
+  }
+
+  // Extract from model:success
+  const success = traces.find((e) => e.message === 'model:success');
+  if (success?.details) {
+    stats.inputTokens = success.details.inputTokens ?? null;
+    stats.outputTokens = success.details.outputTokens ?? null;
+    stats.cachedTokens = success.details.cachedInputTokens ?? null;
+    stats.latencyMs = success.details.latencyMs ?? null;
+    stats.ttftMs = success.details.ttftMs ?? null;
+    stats.tokensPerSec = success.details.tokensPerSec ?? null;
+  }
+
+  // Check for errors
+  const error = traces.find((e) => e.message === 'model:error');
+  if (error) {
+    stats.hasError = true;
+    stats.errorMessage = error.details?.error ?? error.details?.message ?? 'Unknown error';
+  }
+
+  return stats;
+}
+/* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+
+export function formatDuration(ms: number | null): string {
+  if (ms == null) return '—';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+export function formatTokensPerSec(tps: number | null): string {
+  if (tps == null) return '—';
+  return `${Math.round(tps)} T/s`;
+}
+
+export function formatTokens(count: number | null): string {
+  if (count == null) return '—';
+  return count.toLocaleString();
+}

--- a/packages/dashboard/src/utils/traceUtils.ts
+++ b/packages/dashboard/src/utils/traceUtils.ts
@@ -17,6 +17,12 @@ export interface MessageStats {
   latencyMs: number | null;
   ttftMs: number | null;
   tokensPerSec: number | null;
+  // Cost information
+  inputCostUsd: number | null;
+  outputCostUsd: number | null;
+  totalCostUsd: number | null;
+  inputPerMillion: number | null;
+  outputPerMillion: number | null;
   hasError: boolean;
   errorMessage?: string;
 }
@@ -36,6 +42,11 @@ export function extractMessageStats(traces: TraceEntry[]): MessageStats {
     latencyMs: null,
     ttftMs: null,
     tokensPerSec: null,
+    inputCostUsd: null,
+    outputCostUsd: null,
+    totalCostUsd: null,
+    inputPerMillion: null,
+    outputPerMillion: null,
     hasError: false,
   };
 
@@ -57,6 +68,12 @@ export function extractMessageStats(traces: TraceEntry[]): MessageStats {
     stats.latencyMs = success.details.latencyMs ?? null;
     stats.ttftMs = success.details.ttftMs ?? null;
     stats.tokensPerSec = success.details.tokensPerSec ?? null;
+    // Extract cost information
+    stats.inputCostUsd = success.details.inputCostUsd ?? null;
+    stats.outputCostUsd = success.details.outputCostUsd ?? null;
+    stats.totalCostUsd = success.details.totalCostUsd ?? null;
+    stats.inputPerMillion = success.details.inputPerMillion ?? null;
+    stats.outputPerMillion = success.details.outputPerMillion ?? null;
   }
 
   // Check for errors
@@ -79,6 +96,15 @@ export function formatDuration(ms: number | null): string {
 export function formatTokensPerSec(tps: number | null): string {
   if (tps == null) return '—';
   return `${Math.round(tps)} T/s`;
+}
+
+export function formatCost(usd: number | null): string {
+  if (usd == null) return '—';
+  if (usd === 0) return '$0.000';
+  if (usd < 0.000001) return '<$0.000001';
+  if (usd < 0.01) return `$${usd.toFixed(6)}`;
+  if (usd < 1) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
 }
 
 export function formatTokens(count: number | null): string {

--- a/packages/service/src/config/loader.ts
+++ b/packages/service/src/config/loader.ts
@@ -53,7 +53,14 @@ export async function readConfig<K extends keyof StoredTypeMap>(
   const filePath = CONFIG_PATHS[key];
   try {
     const raw = await readFile(filePath, 'utf-8');
-    return JSON.parse(raw) as StoredTypeMap[K];
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      // File exists but is empty — treat as missing
+      const defaultValue = DEFAULTS[key] as StoredTypeMap[K];
+      await writeConfig(key, defaultValue);
+      return defaultValue;
+    }
+    return JSON.parse(trimmed) as StoredTypeMap[K];
   } catch (err: unknown) {
     if (isNodeError(err) && err.code === 'ENOENT') {
       const defaultValue = DEFAULTS[key] as StoredTypeMap[K];

--- a/packages/service/src/cost/tracker.ts
+++ b/packages/service/src/cost/tracker.ts
@@ -34,6 +34,15 @@ export async function trackUsage(params: TrackUsageParams): Promise<void> {
     params.cacheCreationInputTokens,
   );
 
+  // Calculate input/output cost breakdown for reporting
+  const plainInput = params.inputTokens - (params.cachedInputTokens ?? 0) - (params.cacheCreationInputTokens ?? 0);
+  const costInput = Math.round((
+    (plainInput / 1_000_000) * params.model.cost.inputPerMillion +
+    ((params.cachedInputTokens ?? 0) / 1_000_000) * (params.model.cost.cachePerMillion ?? params.model.cost.inputPerMillion) +
+    ((params.cacheCreationInputTokens ?? 0) / 1_000_000) * (params.model.cost.cacheWritePerMillion ?? params.model.cost.inputPerMillion)
+  ) * 1_000_000) / 1_000_000;
+  const costOutput = Math.round(((params.outputTokens / 1_000_000) * params.model.cost.outputPerMillion) * 1_000_000) / 1_000_000;
+
   const record: UsageRecord = {
     id: uuidv4(),
     timestamp: new Date().toISOString(),
@@ -51,6 +60,11 @@ export async function trackUsage(params: TrackUsageParams): Promise<void> {
     ...(params.errorMessage !== undefined ? { errorMessage: params.errorMessage } : {}),
     callType: params.callType ?? 'completion',
     ...(params.traceId ? { trace: getTrace(params.traceId) ?? [] } : {}),
+    ...(params.traceId ? { traceId: params.traceId } : {}),
+    costInput,
+    costOutput,
+    priceInput: params.model.cost.inputPerMillion,
+    priceOutput: params.model.cost.outputPerMillion,
   };
 
   await appendUsageRecord(record);

--- a/packages/service/src/llm/executor.ts
+++ b/packages/service/src/llm/executor.ts
@@ -161,15 +161,21 @@ export async function llmChat(
       : undefined;
     const responseJSON = isRouting ? response : undefined;
 
+    const inputTokens = response.usage?.prompt_tokens ?? 0;
+    const outputTokens = response.usage?.completion_tokens ?? 0;
+    const tokensPerSec = latencyMs > 0 ? Math.round((inputTokens + outputTokens) / (latencyMs / 1000)) : 0;
+
     emit?.({
       panel: res,
       message: 'model:success',
       details: {
         modelId: model.id,
-        inputTokens: response.usage?.prompt_tokens,
+        inputTokens,
         cachedInputTokens: response.usage?.prompt_tokens_details?.cached_tokens,
-        outputTokens: response.usage?.completion_tokens,
+        outputTokens,
         latencyMs,
+        ttftMs: latencyMs,  // non-streaming: tutta la latenza ≡ TTFT
+        tokensPerSec,
         ...(responseText != null ? { responseText } : {}),
         ...(responseJSON != null ? { responseJSON } : {}),
       },
@@ -367,6 +373,7 @@ export async function llmStream(
     } finally {
       const latencyMs = Date.now() - t0;
       if (outcome === 'success') {
+        const tokensPerSec = latencyMs > 0 ? Math.round((inputTokens + outputTokens) / (latencyMs / 1000)) : 0;
         emit?.({
           panel: res,
           message: 'model:success',
@@ -376,6 +383,8 @@ export async function llmStream(
             cachedInputTokens: cachedInputTokens > 0 ? cachedInputTokens : undefined,
             outputTokens,
             latencyMs,
+            ttftMs,
+            tokensPerSec,
           },
         });
       }

--- a/packages/service/src/llm/executor.ts
+++ b/packages/service/src/llm/executor.ts
@@ -163,7 +163,15 @@ export async function llmChat(
 
     const inputTokens = response.usage?.prompt_tokens ?? 0;
     const outputTokens = response.usage?.completion_tokens ?? 0;
+    const cachedTokens = response.usage?.prompt_tokens_details?.cached_tokens ?? 0;
     const tokensPerSec = latencyMs > 0 ? Math.round((inputTokens + outputTokens) / (latencyMs / 1000)) : 0;
+
+    // Calculate costs
+    const plainInput = inputTokens - cachedTokens;
+    const inputCostUsd = (plainInput / 1_000_000) * model.cost.inputPerMillion;
+    const cachedCostUsd = (cachedTokens / 1_000_000) * (model.cost.cachePerMillion ?? model.cost.inputPerMillion);
+    const outputCostUsd = (outputTokens / 1_000_000) * model.cost.outputPerMillion;
+    const totalCostUsd = inputCostUsd + cachedCostUsd + outputCostUsd;
 
     emit?.({
       panel: res,
@@ -171,11 +179,17 @@ export async function llmChat(
       details: {
         modelId: model.id,
         inputTokens,
-        cachedInputTokens: response.usage?.prompt_tokens_details?.cached_tokens,
+        cachedInputTokens: cachedTokens,
         outputTokens,
         latencyMs,
         ttftMs: latencyMs,  // non-streaming: tutta la latenza ≡ TTFT
         tokensPerSec,
+        // Cost information
+        inputCostUsd,
+        outputCostUsd,
+        totalCostUsd,
+        inputPerMillion: model.cost.inputPerMillion,
+        outputPerMillion: model.cost.outputPerMillion,
         ...(responseText != null ? { responseText } : {}),
         ...(responseJSON != null ? { responseJSON } : {}),
       },
@@ -374,6 +388,14 @@ export async function llmStream(
       const latencyMs = Date.now() - t0;
       if (outcome === 'success') {
         const tokensPerSec = latencyMs > 0 ? Math.round((inputTokens + outputTokens) / (latencyMs / 1000)) : 0;
+        
+        // Calculate costs
+        const plainInput = inputTokens - cachedInputTokens;
+        const inputCostUsd = (plainInput / 1_000_000) * model.cost.inputPerMillion;
+        const cachedCostUsd = (cachedInputTokens / 1_000_000) * (model.cost.cachePerMillion ?? model.cost.inputPerMillion);
+        const outputCostUsd = (outputTokens / 1_000_000) * model.cost.outputPerMillion;
+        const totalCostUsd = inputCostUsd + cachedCostUsd + outputCostUsd;
+        
         emit?.({
           panel: res,
           message: 'model:success',
@@ -385,6 +407,12 @@ export async function llmStream(
             latencyMs,
             ttftMs,
             tokensPerSec,
+            // Cost information
+            inputCostUsd,
+            outputCostUsd,
+            totalCostUsd,
+            inputPerMillion: model.cost.inputPerMillion,
+            outputPerMillion: model.cost.outputPerMillion,
           },
         });
       }

--- a/packages/service/src/providers/anthropic.ts
+++ b/packages/service/src/providers/anthropic.ts
@@ -132,11 +132,18 @@ export class AnthropicAdapter implements ProviderAdapter {
 
     const params: any = {
       model: upstreamModel,
-      max_tokens: request.max_tokens ?? 4096,
+      max_tokens: request.max_completion_tokens ?? request.max_tokens ?? 4096,
       messages: this.convertMessages(nonSystemMessages),
     };
     if (systemMessage?.content) {
       params.system = this.convertSystem(systemMessage.content as string | any[]);
+    }
+
+    // Extended thinking — requires min 16k max_tokens per Anthropic spec
+    const thinkingEnabled = model.capabilities?.thinking === true;
+    if (thinkingEnabled) {
+      params.thinking = { type: 'enabled', budget_tokens: 10000 };
+      if ((params.max_tokens as number) < 16000) params.max_tokens = 16000;
     }
 
     const response = await client.messages.create(params);
@@ -187,7 +194,7 @@ export class AnthropicAdapter implements ProviderAdapter {
 
     const params: any = {
       model: upstreamModel,
-      max_tokens: request.max_tokens ?? 4096,
+      max_tokens: request.max_completion_tokens ?? request.max_tokens ?? 4096,
       messages: this.convertMessages(nonSystemMessages),
       stream: true,
     };

--- a/packages/service/src/providers/custom.ts
+++ b/packages/service/src/providers/custom.ts
@@ -20,14 +20,27 @@ export class CustomAdapter implements ProviderAdapter {
     return new OpenAI({ apiKey, baseURL: model.endpoint });
   }
 
+  // Resolve the model identifier to send to the upstream API.
+  // Prefers the explicit upstreamModelId field; falls back to stripping the provider prefix.
+  // e.g. upstreamModelId="deepseek-reasoner" → "deepseek-reasoner"
+  // e.g. id="deepseek/deepseek-r1" (no upstreamModelId) → "deepseek-r1"
+  private getUpstreamModelId(model: ModelConfig): string {
+    if (model.upstreamModelId) return model.upstreamModelId;
+    if (model.id.includes('/')) {
+      return model.id.split('/').slice(1).join('/');
+    }
+    return model.id;
+  }
+
   async chatCompletion(
     request: ChatCompletionRequest,
     model: ModelConfig,
   ): Promise<ChatCompletionResponse> {
     const client = this.getClient(model);
+    const upstreamModel = this.getUpstreamModelId(model);
     const { stream: _stream, ...rest } = request;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response = await client.chat.completions.create({ ...rest, stream: false } as any);
+    const response = await client.chat.completions.create({ ...rest, model: upstreamModel, stream: false } as any);
     return response as unknown as ChatCompletionResponse;
   }
 
@@ -36,9 +49,10 @@ export class CustomAdapter implements ProviderAdapter {
     model: ModelConfig,
   ): AsyncIterable<StreamChunk> {
     const client = this.getClient(model);
+    const upstreamModel = this.getUpstreamModelId(model);
     const { stream: _stream, ...rest } = request;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const stream: any = await client.chat.completions.create({ ...rest, stream: true } as any);
+    const stream: any = await client.chat.completions.create({ ...rest, model: upstreamModel, stream: true } as any);
     for await (const chunk of stream) {
       yield chunk as unknown as StreamChunk;
     }

--- a/packages/service/src/providers/ollama.ts
+++ b/packages/service/src/providers/ollama.ts
@@ -24,15 +24,31 @@ export class OllamaAdapter implements ProviderAdapter {
     return model.id;
   }
 
+  // Ollama's OpenAI-compat endpoint uses max_tokens (maps to num_predict).
+  // It does NOT recognize max_completion_tokens, so we normalize here.
+  // Also, Qwen3 and other thinking-capable models on Ollama generate reasoning
+  // tokens by default; passing think:false disables it for routing calls.
+  private normalizeRequest(req: ChatCompletionRequest, model: ModelConfig): Record<string, unknown> {
+    const { stream: _stream, max_completion_tokens, max_tokens, ...rest } = req;
+    const resolved = max_tokens ?? max_completion_tokens;
+    const thinkingEnabled = model.capabilities?.thinking === true;
+    return {
+      ...rest,
+      ...(resolved != null ? { max_tokens: resolved } : {}),
+      // Disable built-in thinking unless explicitly enabled via model capability
+      ...(!thinkingEnabled ? { think: false } : {}),
+    };
+  }
+
   async chatCompletion(
     request: ChatCompletionRequest,
     model: ModelConfig,
   ): Promise<ChatCompletionResponse> {
     const client = this.getClient(model);
-    const { stream: _stream, ...rest } = request;
+    const normalized = this.normalizeRequest(request, model);
     const upstreamModel = this.getUpstreamModelId(model);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response = await client.chat.completions.create({ ...rest, model: upstreamModel, stream: false } as any);
+    const response = await client.chat.completions.create({ ...normalized, model: upstreamModel, stream: false } as any);
     return response as unknown as ChatCompletionResponse;
   }
 
@@ -41,10 +57,10 @@ export class OllamaAdapter implements ProviderAdapter {
     model: ModelConfig,
   ): AsyncIterable<StreamChunk> {
     const client = this.getClient(model);
-    const { stream: _stream, ...rest } = request;
+    const normalized = this.normalizeRequest(request, model);
     const upstreamModel = this.getUpstreamModelId(model);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const stream: any = await client.chat.completions.create({ ...rest, model: upstreamModel, stream: true } as any);
+    const stream: any = await client.chat.completions.create({ ...normalized, model: upstreamModel, stream: true } as any);
     for await (const chunk of stream) {
       yield chunk as unknown as StreamChunk;
     }

--- a/packages/service/src/providers/ollama.ts
+++ b/packages/service/src/providers/ollama.ts
@@ -48,7 +48,18 @@ export class OllamaAdapter implements ProviderAdapter {
     const normalized = this.normalizeRequest(request, model);
     const upstreamModel = this.getUpstreamModelId(model);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response = await client.chat.completions.create({ ...normalized, model: upstreamModel, stream: false } as any);
+    const response = await client.chat.completions.create({ ...normalized, model: upstreamModel, stream: false } as any) as any;
+    // Some Qwen3 variants on Ollama (thinking models) put all content in `message.thinking`
+    // even when think:false is requested, leaving `message.content` empty.
+    // Fall back to thinking content so callers always receive a non-empty response.
+    const thinkingEnabled = model.capabilities?.thinking === true;
+    if (!thinkingEnabled) {
+      const msg = response?.choices?.[0]?.message as any;
+      if (msg && !msg.content && msg.thinking) {
+        msg.content = msg.thinking;
+        delete msg.thinking;
+      }
+    }
     return response as unknown as ChatCompletionResponse;
   }
 
@@ -59,9 +70,20 @@ export class OllamaAdapter implements ProviderAdapter {
     const client = this.getClient(model);
     const normalized = this.normalizeRequest(request, model);
     const upstreamModel = this.getUpstreamModelId(model);
+    const thinkingEnabled = model.capabilities?.thinking === true;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const stream: any = await client.chat.completions.create({ ...normalized, model: upstreamModel, stream: true } as any);
     for await (const chunk of stream) {
+      // Same fallback as chatCompletion: remap delta.thinking → delta.content when
+      // think:false was requested but the model still emits thinking-only chunks.
+      if (!thinkingEnabled) {
+        const delta = (chunk as any)?.choices?.[0]?.delta as any;
+        if (delta?.thinking && !delta.content) {
+          const { thinking, ...deltaRest } = delta;
+          yield { ...(chunk as any), choices: [{ ...(chunk as any).choices[0], delta: { ...deltaRest, content: thinking } }, ...(chunk as any).choices.slice(1)] } as unknown as StreamChunk;
+          continue;
+        }
+      }
       yield chunk as unknown as StreamChunk;
     }
   }

--- a/packages/service/src/providers/openai.ts
+++ b/packages/service/src/providers/openai.ts
@@ -27,15 +27,39 @@ export class OpenAIAdapter implements ProviderAdapter {
     return model.id;
   }
 
+  // Normalize max_tokens → max_completion_tokens.
+  // Newer OpenAI models (o1, o3, o4-mini, gpt-4.5, …) reject max_tokens with a 400.
+  private normalizeTokenLimit(req: ChatCompletionRequest): Omit<ChatCompletionRequest, 'max_tokens'> {
+    const { max_tokens, max_completion_tokens, ...rest } = req;
+    const resolved = max_completion_tokens ?? max_tokens;
+    return resolved != null ? { ...rest, max_completion_tokens: resolved } : rest;
+  }
+
+  // o-series models (o1, o3, o4-mini, …) support reasoning_effort; GPT-family models do not.
+  private isReasoningModel(modelId: string): boolean {
+    return /^o\d/.test(modelId);
+  }
+
+  // Strip reasoning-model-only params when forwarding to non-o-series models.
+  private normalizeForModel(req: ChatCompletionRequest, upstreamModel: string): Record<string, unknown> {
+    const { stream: _stream, ...normalized } = this.normalizeTokenLimit(req);
+    if (!this.isReasoningModel(upstreamModel)) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { reasoning_effort, reasoning_summary, ...safe } = normalized as Record<string, unknown>;
+      return safe;
+    }
+    return normalized as Record<string, unknown>;
+  }
+
   async chatCompletion(
     request: ChatCompletionRequest,
     model: ModelConfig,
   ): Promise<ChatCompletionResponse> {
     const client = this.getClient(model);
-    const { stream: _stream, ...rest } = request;
 
     // Override the requested model with the actual selected candidate model ID
     const upstreamModel = this.getUpstreamModelId(model);
+    const rest = this.normalizeForModel(request, upstreamModel);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const response = await client.chat.completions.create({ ...rest, model: upstreamModel, stream: false } as any);
@@ -48,9 +72,8 @@ export class OpenAIAdapter implements ProviderAdapter {
     model: ModelConfig,
   ): AsyncIterable<StreamChunk> {
     const client = this.getClient(model);
-    const { stream: _stream, ...rest } = request;
-
     const upstreamModel = this.getUpstreamModelId(model);
+    const rest = this.normalizeForModel(request, upstreamModel);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const stream: any = await client.chat.completions.create({ ...rest, model: upstreamModel, stream: true } as any);

--- a/packages/service/src/routes/anthropic.ts
+++ b/packages/service/src/routes/anthropic.ts
@@ -43,6 +43,7 @@ export const anthropicRoutes: FastifyPluginAsync = async (fastify) => {
 
     const emit = (entry: TraceEntry) => {
       appendTrace(traceId, [entry]);
+      reply.raw.write(`data: ${JSON.stringify({ type: 'trace', entry })}\n\n`);
     };
 
     // 1. Route request

--- a/packages/service/src/routes/api.ts
+++ b/packages/service/src/routes/api.ts
@@ -168,7 +168,8 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.post<{
     Body: {
       id: string; name?: string; provider: string; endpoint: string;
-      apiKey?: string; cloneFrom?: string; inputPerMillion: number; outputPerMillion: number;
+      apiKey?: string; cloneFrom?: string; upstreamModelId?: string;
+      inputPerMillion: number; outputPerMillion: number;
       cachePerMillion?: number;
       contextWindow?: number;
       pricingTiers?: PricingTier[];
@@ -213,6 +214,7 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
       },
       ...(resolvedLimits?.length ? { limits: resolvedLimits } : {}),
       ...(req.body.contextWindow !== undefined ? { contextWindow: req.body.contextWindow } : {}),
+      ...(req.body.upstreamModelId ? { upstreamModelId: req.body.upstreamModelId } : {}),
     };
     models.push(model);
     await writeConfig('models', models);
@@ -224,7 +226,8 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
     Body: {
       id?: string;
       name?: string; provider: string; endpoint: string;
-      apiKey?: string; inputPerMillion: number; outputPerMillion: number;
+      apiKey?: string; upstreamModelId?: string;
+      inputPerMillion: number; outputPerMillion: number;
       cachePerMillion?: number;
       contextWindow?: number;
       pricingTiers?: PricingTier[];
@@ -277,9 +280,41 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
       globalThresholds: undefined,
       ...(req.body.contextWindow !== undefined ? { contextWindow: req.body.contextWindow } : existing.contextWindow !== undefined ? { contextWindow: existing.contextWindow } : {}),
       ...(resolvedLimits?.length ? { limits: resolvedLimits } : {}),
+      // upstreamModelId: if explicitly provided keep it, if empty string clear it, if absent keep existing
+      ...(req.body.upstreamModelId
+        ? { upstreamModelId: req.body.upstreamModelId }
+        : req.body.upstreamModelId === ''
+          ? { upstreamModelId: undefined }
+          : existing.upstreamModelId !== undefined ? { upstreamModelId: existing.upstreamModelId } : {}),
     };
     models[index] = model;
     await writeConfig('models', models);
+
+    // If the model ID changed, cascade the rename to all project references
+    if (newId !== req.params.id) {
+      const projects = await readConfig('projects');
+      let projectsChanged = false;
+      for (const project of projects) {
+        for (const ref of (project.models ?? [])) {
+          if (ref.modelId === req.params.id) {
+            ref.modelId = newId;
+            projectsChanged = true;
+          }
+        }
+        for (const token of (project.tokens ?? [])) {
+          for (const ref of (token.models ?? [])) {
+            if (ref.modelId === req.params.id) {
+              ref.modelId = newId;
+              projectsChanged = true;
+            }
+          }
+        }
+      }
+      if (projectsChanged) {
+        await writeConfig('projects', projects);
+      }
+    }
+
     return reply.send({ ...model, apiKey: undefined });
   });
 

--- a/packages/service/src/routes/api.ts
+++ b/packages/service/src/routes/api.ts
@@ -644,10 +644,12 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
   // USAGE STATS
   // ══════════════════════════════════════════════════════════════════════════════
 
-  fastify.get<{ Querystring: { period?: string; projectId?: string; from?: string; to?: string } }>('/api/usage', async (req, reply) => {
+  fastify.get<{ Querystring: { period?: string; projectId?: string; from?: string; to?: string; page?: string; pageSize?: string } }>('/api/usage', async (req, reply) => {
     if (!requirePerm(req, 'report:read', reply)) return;
     const records = await readConfig('usage');
     const { period = 'monthly', projectId, from, to } = req.query;
+    const page = Math.max(1, parseInt(req.query.page ?? '1', 10) || 1);
+    const pageSize = Math.min(200, Math.max(1, parseInt(req.query.pageSize ?? '50', 10) || 50));
 
     const now = new Date();
     let since = new Date(0);
@@ -660,8 +662,15 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
       since.setHours(0, 0, 0, 0);
     } else if (period === 'monthly') { since = new Date(now); since.setDate(1); since.setHours(0, 0, 0, 0); }
     else if (period === 'custom') {
-      if (from) { since = new Date(from); since.setHours(0, 0, 0, 0); }
-      if (to)   { until = new Date(to);  until.setHours(23, 59, 59, 999); }
+      if (from) {
+        since = new Date(from);
+        // Only normalize to day boundary for date-only strings (YYYY-MM-DD)
+        if (from.length <= 10) since.setHours(0, 0, 0, 0);
+      }
+      if (to) {
+        until = new Date(to);
+        if (to.length <= 10) until.setHours(23, 59, 59, 999);
+      }
     }
 
     let filtered = records.filter(r => {
@@ -700,12 +709,21 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
     const totalCalls = filtered.length;
     const successCalls = filtered.filter(r => r.outcome === 'success').length;
 
+    // Paginate records (most recent first)
+    const sorted = [...filtered].reverse();
+    const totalRecords = sorted.length;
+    const totalPages = Math.max(1, Math.ceil(totalRecords / pageSize));
+    const safePage = Math.min(page, totalPages);
+    const startIdx = (safePage - 1) * pageSize;
+    const paged = sorted.slice(startIdx, startIdx + pageSize);
+
     return reply.send({
       summary: { totalCost, totalCalls, successCalls, errorCalls: totalCalls - successCalls, routingCalls, completionCalls, routingCost, completionCost },
       byModel,
       timeline: Object.entries(timeline).sort(([a], [b]) => a.localeCompare(b)).slice(-30),
       // Strip trace from list response to keep payload small
-      records: filtered.slice(-100).reverse().map(({ trace: _trace, ...r }) => r),
+      records: paged.map(({ trace: _trace, ...r }) => r),
+      pagination: { page: safePage, pageSize, totalRecords, totalPages },
     });
   });
 

--- a/packages/service/src/routes/api.ts
+++ b/packages/service/src/routes/api.ts
@@ -262,7 +262,7 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
         ]
         : undefined;
 
-    const { limits: _existingLimits, ...existingWithoutLimits } = existing;
+    const { limits: _existingLimits, upstreamModelId: _existingUpstreamModelId, ...existingWithoutLimits } = existing;
     const model: ModelConfig = {
       ...existingWithoutLimits,
       id: newId,
@@ -283,9 +283,9 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
       // upstreamModelId: if explicitly provided keep it, if empty string clear it, if absent keep existing
       ...(req.body.upstreamModelId
         ? { upstreamModelId: req.body.upstreamModelId }
-        : req.body.upstreamModelId === ''
-          ? { upstreamModelId: undefined }
-          : existing.upstreamModelId !== undefined ? { upstreamModelId: existing.upstreamModelId } : {}),
+        : req.body.upstreamModelId === undefined && _existingUpstreamModelId !== undefined
+          ? { upstreamModelId: _existingUpstreamModelId }
+          : {}),
     };
     models[index] = model;
     await writeConfig('models', models);

--- a/packages/service/src/routes/openai.ts
+++ b/packages/service/src/routes/openai.ts
@@ -2,6 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import { randomUUID } from 'node:crypto';
 import type { ChatCompletionRequest, ModelObject } from '@routerly/shared';
 import { routeRequest } from '../routing/router.js';
+import { addRoutingDecision } from '../routing/routingMemoryStore.js';
 import { readConfig } from '../config/loader.js';
 import { setTrace, appendTrace } from '../routing/traceStore.js';
 import type { TraceEntry } from '../routing/traceStore.js';
@@ -70,6 +71,10 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
 
     const traceId = randomUUID();
     setTrace(traceId, []);
+    const conversationId = (request.headers['x-routerly-conversation-id'] as string | undefined) || undefined;
+    const isMemoryEnabled = (project.policies ?? []).some(
+      (p: any) => p.type === 'llm' && p.enabled && p.config?.memory === true,
+    );
 
     if (isStream) {
       // ── Streaming path: avvia SSE subito ──────────────────────────────────
@@ -93,7 +98,7 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
 
       let routingResponse;
       try {
-        routingResponse = await routeRequest(body, project, request.log, emit, request.token, traceId);
+        routingResponse = await routeRequest(body, project, request.log, emit, request.token, traceId, conversationId);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         request.log.error({ err }, 'Routing model failed');
@@ -102,6 +107,10 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
         reply.raw.write('data: [DONE]\n\n');
         reply.raw.end();
         return;
+      }
+
+      if (isMemoryEnabled && conversationId && routingResponse.models.length > 0) {
+        addRoutingDecision(project.id, conversationId, routingResponse.models[0].model);
       }
 
       const allModelsList = await readConfig('models');
@@ -166,11 +175,15 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
 
     let routingResponse;
     try {
-      routingResponse = await routeRequest(body, project, request.log, emit, request.token, traceId);
+      routingResponse = await routeRequest(body, project, request.log, emit, request.token, traceId, conversationId);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       request.log.error({ err }, 'Routing model failed');
       return reply.code(500).send({ error: { message: `Routing model failed: ${msg}`, type: 'server_error' } });
+    }
+
+    if (isMemoryEnabled && conversationId && routingResponse.models.length > 0) {
+      addRoutingDecision(project.id, conversationId, routingResponse.models[0].model);
     }
 
     const allModelsList = await readConfig('models');

--- a/packages/service/src/routes/openai.ts
+++ b/packages/service/src/routes/openai.ts
@@ -56,6 +56,18 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
     const body = request.body;
     const isStream = body.stream === true;
 
+    const msgs = body.messages ?? [];
+    const payloadChars = JSON.stringify(msgs).length;
+    request.log.info(
+      {
+        messageCount: msgs.length,
+        roles: msgs.map((m: any) => m.role),
+        payloadChars,
+        stream: isStream,
+      },
+      'completion: request',
+    );
+
     const traceId = randomUUID();
     setTrace(traceId, []);
 
@@ -120,10 +132,14 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
         }
 
         try {
+          let fullContent = '';
           for await (const chunk of streamResult.chunks) {
             reply.raw.write(`data: ${JSON.stringify(chunk)}\n\n`);
+            const delta = chunk.choices?.[0]?.delta?.content;
+            if (delta) fullContent += delta;
           }
           reply.raw.write('data: [DONE]\n\n');
+          request.log.info({ modelId: model.id, contentChars: fullContent.length }, 'completion: response');
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
           request.log.error({ err, modelId: model.id }, 'Streaming error mid-stream');
@@ -176,6 +192,15 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
 
       try {
         const response = await llmChat(body, model, ctx);
+        request.log.info(
+          {
+            modelId: model.id,
+            inputTokens: response.usage?.prompt_tokens,
+            outputTokens: response.usage?.completion_tokens,
+            finishReason: response.choices?.[0]?.finish_reason,
+          },
+          'completion: response',
+        );
         reply.header('x-routerly-trace-id', traceId);
         return reply.send(response);
       } catch (err: unknown) {

--- a/packages/service/src/routes/openai.ts
+++ b/packages/service/src/routes/openai.ts
@@ -76,6 +76,7 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
 
       const emit = (entry: TraceEntry) => {
         appendTrace(traceId, [entry]);
+        reply.raw.write(`data: ${JSON.stringify({ type: 'trace', entry })}\n\n`);
       };
 
       let routingResponse;

--- a/packages/service/src/routes/openai.ts
+++ b/packages/service/src/routes/openai.ts
@@ -110,7 +110,7 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
       }
 
       if (isMemoryEnabled && conversationId && routingResponse.models.length > 0) {
-        addRoutingDecision(project.id, conversationId, routingResponse.models[0].model);
+        addRoutingDecision(project.id, conversationId, routingResponse.models[0]!.model);
       }
 
       const allModelsList = await readConfig('models');
@@ -183,7 +183,7 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
     }
 
     if (isMemoryEnabled && conversationId && routingResponse.models.length > 0) {
-      addRoutingDecision(project.id, conversationId, routingResponse.models[0].model);
+      addRoutingDecision(project.id, conversationId, routingResponse.models[0]!.model);
     }
 
     const allModelsList = await readConfig('models');

--- a/packages/service/src/routing/policies/llm.ts
+++ b/packages/service/src/routing/policies/llm.ts
@@ -9,10 +9,11 @@ import type { PolicyFn } from './types.js';
 
 function buildSystemPrompt(
   candidates: { id: string; prompt?: string; limits?: LimitSnapshot[] }[],
-  additionalPromptInfo?: string,
+  options: { additionalPromptInfo?: string; includeReason?: boolean } = {},
 ): string {
-  const hasAnyPrompt  = candidates.some(c => c.prompt);
-  const hasAnyLimits  = candidates.some(c => c.limits && c.limits.length > 0);
+  const { additionalPromptInfo, includeReason = false } = options;
+  const hasAnyPrompt = candidates.some(c => c.prompt);
+  const hasAnyLimits = candidates.some(c => c.limits && c.limits.length > 0);
 
   const modelList = candidates
     .map(c => {
@@ -29,35 +30,39 @@ function buildSystemPrompt(
     .join('\n');
 
   const guidanceRule = hasAnyPrompt
-    ? `- When a model has a "routing_guidance" field, treat it as a direct instruction from the operator about when that model should be preferred. Weight it heavily in your scoring: a request that matches the guidance should receive a high score (≥ 0.8), while a request that clearly contradicts it should receive a low score (≤ 0.3).`
+    ? `- routing_guidance fields are operator instructions — weight them heavily: matching request → score ≥ 0.8, contradicting → score ≤ 0.3.`
     : '';
 
   const limitsRule = hasAnyLimits
-    ? `- When a model has a "limits" block, each entry shows the current consumption vs the configured threshold for a given window. A model with low "remaining" quota is approaching exhaustion: prefer models with more headroom, unless other factors strongly favour the constrained model.`
+    ? `- limits blocks show current consumption vs threshold — prefer models with more "remaining" headroom unless other factors strongly justify the opposite.`
     : '';
 
-  const extraRules = [guidanceRule, limitsRule].filter(Boolean).map(r => `- ${r.replace(/^- /, '')}`).join('\n');
+  const extraRules = [guidanceRule, limitsRule].filter(Boolean).join('\n');
 
   const additionalBlock = additionalPromptInfo?.trim()
     ? `\n\nAdditional context:\n${additionalPromptInfo.trim()}`
     : '';
 
-  return `You are a routing assistant. Score each model by how well it fits the request (0.0 = worst, 1.0 = best).
+  const entryFormat = includeReason
+    ? `{ "model": "<id>", "point": <0.0-1.0>, "reason": "<brief>" }`
+    : `{ "model": "<id>", "point": <0.0-1.0> }`;
 
-"Best fit" is the most appropriate model, not the most powerful. Match task complexity to model capability: simple tasks suit smaller models; complex tasks need stronger ones. Using a flagship model for a trivial task is a poor fit.
+  return `You are a routing assistant. Score each model 0.0–1.0 (worst → best).
 
-Available models:
+Match complexity to capability: simple tasks → cheap models, hard tasks → powerful models.
+
+Models:
 ${modelList}
 
 Rules:
 - Return ONLY a JSON object — no markdown, no extra text.
-- Include ALL models using their exact id strings.
-- Scores must reflect real differences; avoid uniform or near-identical values.${extraRules ? `\n${extraRules}` : ''}
+- Include ALL models with their exact id strings.
+- Scores must differ meaningfully.${extraRules ? `\n${extraRules}` : ''}
 
 Format:
 {
   "routing": [
-    { "model": "<model_id>", "point": <0.0-1.0>, "reason": "<brief reason>" },
+    ${entryFormat},
     ...
   ]
 }${additionalBlock}`;
@@ -66,6 +71,7 @@ Format:
 function buildUserMessage(
   request: { messages: { role: string; content: unknown }[] },
   memoryMessages?: { role: string; content: unknown }[],
+  maxChars?: number,
 ): string {
   const msgs = request.messages as Array<{ role: string; content: unknown }>;
 
@@ -83,6 +89,7 @@ function buildUserMessage(
     ? `System prompt:\n${systemContent}\n\n`
     : '';
 
+  let result: string;
   if (memoryMessages && memoryMessages.length > 0) {
     const historyBlock = memoryMessages
       .map(m => {
@@ -90,28 +97,65 @@ function buildUserMessage(
         return `[assistant]: ${c}`;
       })
       .join('\n');
-    return `${systemBlock}Previous assistant responses (most recent last):\n${historyBlock}\n\nCurrent user request:\n${userContent}`;
+    result = `${systemBlock}Previous assistant responses (most recent last):\n${historyBlock}\n\nCurrent user request:\n${userContent}`;
+  } else {
+    result = `${systemBlock}User request:\n${userContent}`;
   }
 
-  return `${systemBlock}User request:\n${userContent}`;
+  if (maxChars != null && result.length > maxChars) {
+    result = result.slice(0, maxChars) + '\n[truncated]';
+  }
+
+  return result;
 }
 
-function parseRoutingResponse(text: string): { model: string; point: number; reason?: string }[] | null {
+function parseRoutingResponse(
+  text: string,
+  log?: { info: (obj: object, msg?: string) => void; warn: (obj: object, msg?: string) => void },
+): { model: string; point: number; reason?: string }[] | null {
   // strip markdown code fences if present
   const cleaned = text.replace(/^```[a-z]*\n?/i, '').replace(/\n?```$/, '').trim();
+
+  // 1) Try strict JSON parse
   try {
     const parsed = JSON.parse(cleaned);
     if (Array.isArray(parsed?.routing)) {
-      // Assicurati che point sia sempre un numero valido
       return parsed.routing.map((r: any) => ({
         model: r.model,
         point: typeof r.point === 'number' && !isNaN(r.point) ? r.point : 0,
         ...(r.reason ? { reason: r.reason } : {}),
       }));
     }
-  } catch {
-    // ignore
+  } catch (err) {
+    log?.warn(
+      { raw: text, error: err instanceof Error ? err.message : String(err) },
+      'llm policy: JSON parse failed, attempting truncated JSON recovery',
+    );
   }
+
+  // 2) Truncated JSON recovery: extract complete routing entries via regex
+  //    Handles cases where max_completion_tokens cuts the response mid-JSON
+  const entryRegex = /\{\s*"model"\s*:\s*"([^"]+)"\s*,\s*"point"\s*:\s*([\d.]+)(?:\s*,\s*"reason"\s*:\s*"([^"]*)")?\s*\}/g;
+  const entries: { model: string; point: number; reason?: string }[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = entryRegex.exec(cleaned)) !== null) {
+    const point = parseFloat(match[2]);
+    entries.push({
+      model: match[1],
+      point: isNaN(point) ? 0 : point,
+      ...(match[3] ? { reason: match[3] } : {}),
+    });
+  }
+
+  if (entries.length > 0) {
+    log?.warn(
+      { recoveredCount: entries.length, raw: text },
+      'llm policy: recovered routing entries from truncated JSON',
+    );
+    return entries;
+  }
+
+  log?.warn({ raw: text }, 'llm policy: unable to parse or recover routing response');
   return null;
 }
 
@@ -121,7 +165,8 @@ async function repairRoutingResponse(
   systemPrompt: string,
   userMessage: string,
   invalidResponse: string,
-  log?: { info: (obj: object, msg?: string) => void },
+  maxCompletionTokens: number | undefined,
+  log?: { info: (obj: object, msg?: string) => void; warn: (obj: object, msg?: string) => void },
 ): Promise<{ model: string; point: number }[] | null> {
   const repairUserMessage = `Your previous response was not valid JSON or did not match the expected structure.
 
@@ -146,31 +191,26 @@ Return ONLY a valid JSON object with no text before or after it, no markdown, no
           { role: 'assistant', content: invalidResponse },
           { role: 'user', content: repairUserMessage },
         ],
-        max_completion_tokens: 2048,
+        ...(maxCompletionTokens != null ? { max_completion_tokens: maxCompletionTokens } : {}),
         stream: false,
       },
       model,
     );
 
     const repairText = String(repairResponse.choices?.[0]?.message?.content ?? '');
-    log?.info({ raw: repairText }, 'llm policy: repair response');
-    return parseRoutingResponse(repairText);
+      log?.debug({ raw: repairText }, 'llm policy: repair response');
+    return parseRoutingResponse(repairText, log);
   } catch (err) {
-    log?.info({ err: String(err) }, 'llm policy: repair call failed');
+      log?.warn({ err: String(err) }, 'llm policy: repair call failed');
     return null;
   }
 }
 
 export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, emit, projectId, token, traceId }) => {
-  log?.info(
+  log?.debug(
     {
-      request: {
-        model: request.model,
-        messages: request.messages,
-        stream: request.stream,
-        temperature: request.temperature,
-        max_tokens: request.max_tokens,
-      },
+      messageCount: request.messages?.length ?? 0,
+      roles: request.messages?.map((m: any) => m.role) ?? [],
       candidates: candidates.map(c => ({ id: c.model.id, provider: c.model.provider })),
       config,
     },
@@ -201,6 +241,19 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
 
   const additionalPromptInfo: string | undefined = config?.additionalPromptInfo;
 
+  // Thinking: se abilitato nel config E il modello di routing lo supporta,
+  // crea una shallow copy con thinking attivo; altrimenti forza thinking: false.
+  // Influenza SOLO la chiamata al modello di routing, MAI la richiesta dell'utente.
+  const thinking: boolean = config?.thinking ?? false;
+  const includeReason: boolean = config?.includeReason ?? false;
+  // Se non configurato, il provider usa il suo default; per Anthropic il fallback è nell'adapter (4096)
+  const maxCompletionTokens: number | undefined = config?.maxCompletionTokens != null
+    ? Math.max(50, config.maxCompletionTokens)
+    : undefined;
+  const maxUserMessageChars: number | undefined = config?.maxUserMessageChars != null
+    ? Math.max(100, config.maxUserMessageChars)
+    : undefined;
+
   // Memory: include the last N assistant responses from the conversation
   let memoryMessages: { role: string; content: unknown }[] | undefined;
   if (config?.memory === true) {
@@ -213,20 +266,20 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
     memoryMessages = sliced.length > 0 ? sliced : undefined;
   }
 
-  const userMessage = buildUserMessage(request, memoryMessages);
+  const userMessage = buildUserMessage(request, memoryMessages, maxUserMessageChars);
   const systemPrompt = buildSystemPrompt(
     candidates.map(c => ({
       id: c.model.id as string,
       ...(c.prompt !== undefined ? { prompt: c.prompt } : {}),
       ...(limitsMap[c.model.id as string]?.length ? { limits: limitsMap[c.model.id as string] } : {}),
     })),
-    additionalPromptInfo,
+    { additionalPromptInfo, includeReason },
   );
 
-  log?.info(
+  log?.debug(
     {
-      systemPrompt,
-      userMessage: '[redacted]',
+      systemPromptChars: systemPrompt.length,
+      userMessageChars: userMessage.length,
     },
     'llm policy: prompts',
   );
@@ -234,10 +287,14 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
   for (const modelId of candidateModelIds) {
     const model = allModels.find(m => m.id === modelId);
     if (!model) {
-      log?.info({ modelId, reason: 'model not found' }, 'llm policy: skipping model');
+      log?.debug({ modelId, reason: 'model not found' }, 'llm policy: skipping model');
       emit?.({ panel: 'router-response', message: 'llm-policy:skip', details: { modelId, reason: 'model not found in config' } });
       continue;
     }
+
+    const routingModel: ModelConfig = thinking && model.capabilities?.thinking === true
+      ? model
+      : { ...model, capabilities: { ...model.capabilities, thinking: false } };
 
     const ctx: LLMCallContext = {
       projectId: projectId ?? '',
@@ -249,18 +306,11 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
       ...(log !== undefined ? { log } : {}),
     };
 
-    log?.info(
+    log?.debug(
       {
         routingModel: modelId,
-        request: {
-          model: model.id,
-          max_completion_tokens: 2048,
-          stream: false,
-          messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: '[redacted]' },
-          ],
-        },
+        messageCount: 2,
+        ...(maxCompletionTokens != null ? { max_completion_tokens: maxCompletionTokens } : {}),
       },
       'llm policy: routing request',
     );
@@ -268,35 +318,35 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
     try {
       const response = await llmChat(
         {
-          model: model.id,
+          model: routingModel.id,
           messages: [
             { role: 'system', content: systemPrompt },
             { role: 'user', content: userMessage },
           ],
-          max_completion_tokens: 2048,
+          ...(maxCompletionTokens != null ? { max_completion_tokens: maxCompletionTokens } : {}),
           stream: false,
         },
-        model,
+        routingModel,
         ctx,
       );
 
       const text = String(response.choices?.[0]?.message?.content ?? '');
-      log?.info({ modelId, raw: text }, 'llm policy: raw response');
+      log?.debug({ modelId, rawChars: text.length }, 'llm policy: raw response');
 
-      const adapter = getProviderAdapter(model);
-      let routing = parseRoutingResponse(text);
+      const adapter = getProviderAdapter(routingModel);
+      let routing = parseRoutingResponse(text, log);
       if (!routing) {
-        log?.info({ modelId, reason: 'parse failed, attempting repair' }, 'llm policy: repair');
-        routing = await repairRoutingResponse(adapter, model, systemPrompt, userMessage, text, log);
+        log?.warn({ modelId, reason: 'parse failed, attempting repair' }, 'llm policy: repair');
+        routing = await repairRoutingResponse(adapter, routingModel, systemPrompt, userMessage, text, maxCompletionTokens, log);
       }
 
       if (!routing) {
-        log?.info({ modelId, reason: 'repair failed' }, 'llm policy: skipping model');
+        log?.error({ modelId, reason: 'repair failed', raw: text }, 'llm policy: all parse attempts failed, skipping model');
         emit?.({ panel: 'router-response', message: 'llm-policy:skip', details: { modelId, reason: 'parse + repair failed' } });
         continue;
       }
 
-      log?.info({ modelId, routing }, 'llm policy: output');
+      log?.debug({ modelId, routing }, 'llm policy: output');
       emit?.({
         panel: 'router-response',
         message: 'llm-policy:scores',
@@ -312,11 +362,11 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
       return { routing };
     } catch (err: unknown) {
       if (err instanceof BudgetExceededError) {
-        log?.info({ modelId, reason: 'budget_exhausted' }, 'llm policy: skipping model');
+        log?.debug({ modelId, reason: 'budget_exhausted' }, 'llm policy: skipping model');
         continue;
       }
       const errMsg = err instanceof Error ? err.message : String(err);
-      log?.info({ modelId, err: errMsg, reason: 'call failed' }, 'llm policy: skipping model');
+      log?.warn({ modelId, err: errMsg, reason: 'call failed' }, 'llm policy: skipping model');
       emit?.({ panel: 'router-response', message: 'llm-policy:error', details: { modelId, error: errMsg } });
     }
   }

--- a/packages/service/src/routing/policies/llm.ts
+++ b/packages/service/src/routing/policies/llm.ts
@@ -137,9 +137,9 @@ function parseRoutingResponse(
   const entries: { model: string; point: number; reason?: string }[] = [];
   let match: RegExpExecArray | null;
   while ((match = entryRegex.exec(cleaned)) !== null) {
-    const point = parseFloat(match[2]);
+    const point = parseFloat(match[2] ?? '');
     entries.push({
-      model: match[1],
+      model: match[1] ?? '',
       point: isNaN(point) ? 0 : point,
       ...(match[3] ? { reason: match[3] } : {}),
     });
@@ -196,7 +196,7 @@ Return ONLY a valid JSON object with no text before or after it, no markdown, no
     );
 
     const repairText = String(repairResponse.choices?.[0]?.message?.content ?? '');
-      log?.debug({ raw: repairText }, 'llm policy: repair response');
+      log?.info({ raw: repairText }, 'llm policy: repair response');
     return parseRoutingResponse(repairText, log);
   } catch (err) {
       log?.warn({ err: String(err) }, 'llm policy: repair call failed');
@@ -205,7 +205,7 @@ Return ONLY a valid JSON object with no text before or after it, no markdown, no
 }
 
 export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, emit, projectId, token, traceId, conversationId }) => {
-  log?.debug(
+  log?.info(
     {
       messageCount: request.messages?.length ?? 0,
       roles: request.messages?.map((m: any) => m.role) ?? [],
@@ -270,10 +270,10 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
       ...(c.prompt !== undefined ? { prompt: c.prompt } : {}),
       ...(limitsMap[c.model.id as string]?.length ? { limits: limitsMap[c.model.id as string] } : {}),
     })),
-    { additionalPromptInfo, includeReason },
+    { ...(additionalPromptInfo !== undefined ? { additionalPromptInfo } : {}), includeReason },
   );
 
-  log?.debug(
+  log?.info(
     {
       systemPromptChars: systemPrompt.length,
       userMessageChars: userMessage.length,
@@ -284,7 +284,7 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
   for (const modelId of candidateModelIds) {
     const model = allModels.find(m => m.id === modelId);
     if (!model) {
-      log?.debug({ modelId, reason: 'model not found' }, 'llm policy: skipping model');
+      log?.info({ modelId, reason: 'model not found' }, 'llm policy: skipping model');
       emit?.({ panel: 'router-response', message: 'llm-policy:skip', details: { modelId, reason: 'model not found in config' } });
       continue;
     }
@@ -303,7 +303,7 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
       ...(log !== undefined ? { log } : {}),
     };
 
-    log?.debug(
+    log?.info(
       {
         routingModel: modelId,
         messageCount: 2,
@@ -328,7 +328,7 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
       );
 
       const text = String(response.choices?.[0]?.message?.content ?? '');
-      log?.debug({ modelId, rawChars: text.length }, 'llm policy: raw response');
+      log?.info({ modelId, rawChars: text.length }, 'llm policy: raw response');
 
       const adapter = getProviderAdapter(routingModel);
       let routing = parseRoutingResponse(text, log);
@@ -343,7 +343,7 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
         continue;
       }
 
-      log?.debug({ modelId, routing }, 'llm policy: output');
+      log?.info({ modelId, routing }, 'llm policy: output');
       emit?.({
         panel: 'router-response',
         message: 'llm-policy:scores',
@@ -359,7 +359,7 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
       return { routing };
     } catch (err: unknown) {
       if (err instanceof BudgetExceededError) {
-        log?.debug({ modelId, reason: 'budget_exhausted' }, 'llm policy: skipping model');
+        log?.info({ modelId, reason: 'budget_exhausted' }, 'llm policy: skipping model');
         continue;
       }
       const errMsg = err instanceof Error ? err.message : String(err);

--- a/packages/service/src/routing/policies/llm.ts
+++ b/packages/service/src/routing/policies/llm.ts
@@ -2,6 +2,7 @@ import type { ModelConfig, ProjectConfig } from '@routerly/shared';
 import { readConfig } from '../../config/loader.js';
 import { getProviderAdapter } from '../../providers/index.js';
 import { llmChat, BudgetExceededError } from '../../llm/executor.js';
+import { getRoutingHistory } from '../routingMemoryStore.js';
 import type { LLMCallContext } from '../../llm/executor.js';
 import { getLimitUsageSnapshot } from '../../cost/budget.js';
 import type { LimitSnapshot } from '../../cost/budget.js';
@@ -70,7 +71,7 @@ Format:
 
 function buildUserMessage(
   request: { messages: { role: string; content: unknown }[] },
-  memoryMessages?: { role: string; content: unknown }[],
+  previousDecisions?: { model: string }[],
   maxChars?: number,
 ): string {
   const msgs = request.messages as Array<{ role: string; content: unknown }>;
@@ -90,14 +91,11 @@ function buildUserMessage(
     : '';
 
   let result: string;
-  if (memoryMessages && memoryMessages.length > 0) {
-    const historyBlock = memoryMessages
-      .map(m => {
-        const c = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
-        return `[assistant]: ${c}`;
-      })
+  if (previousDecisions && previousDecisions.length > 0) {
+    const historyBlock = previousDecisions
+      .map((d, i) => `- Turn ${i + 1}: routed to ${d.model}`)
       .join('\n');
-    result = `${systemBlock}Previous assistant responses (most recent last):\n${historyBlock}\n\nCurrent user request:\n${userContent}`;
+    result = `${systemBlock}Previous routing decisions (most recent last):\n${historyBlock}\n\nCurrent user request:\n${userContent}`;
   } else {
     result = `${systemBlock}User request:\n${userContent}`;
   }
@@ -206,7 +204,7 @@ Return ONLY a valid JSON object with no text before or after it, no markdown, no
   }
 }
 
-export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, emit, projectId, token, traceId }) => {
+export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, emit, projectId, token, traceId, conversationId }) => {
   log?.debug(
     {
       messageCount: request.messages?.length ?? 0,
@@ -239,7 +237,10 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
     }),
   );
 
-  const additionalPromptInfo: string | undefined = config?.additionalPromptInfo;
+  // additionalPromptInfo is only active when autoRouting is explicitly disabled;
+  // when autoRouting is true (or unset), treat it as if none was configured.
+  const additionalPromptInfo: string | undefined =
+    config?.autoRouting === false ? config?.additionalPromptInfo : undefined;
 
   // Thinking: se abilitato nel config E il modello di routing lo supporta,
   // crea una shallow copy con thinking attivo; altrimenti forza thinking: false.
@@ -254,19 +255,15 @@ export const llmPolicy: PolicyFn = async ({ request, candidates, config, log, em
     ? Math.max(100, config.maxUserMessageChars)
     : undefined;
 
-  // Memory: include the last N assistant responses from the conversation
-  let memoryMessages: { role: string; content: unknown }[] | undefined;
-  if (config?.memory === true) {
+  // Memory: recupera le ultime N decisioni di routing per questa conversazione
+  let previousDecisions: { model: string }[] | undefined;
+  if (config?.memory === true && conversationId && projectId) {
     const memoryCount: number = typeof config?.memoryCount === 'number' && config.memoryCount > 0 ? config.memoryCount : 5;
-    const msgs = request.messages as Array<{ role: string; content: unknown }>;
-    const lastUserIdx = msgs.map((m: { role: string }) => m.role).lastIndexOf('user');
-    const historySlice = (lastUserIdx > 0 ? msgs.slice(0, lastUserIdx) : []) as Array<{ role: string; content: unknown }>;
-    const assistantOnly = historySlice.filter((m: { role: string }) => m.role === 'assistant');
-    const sliced = assistantOnly.slice(-memoryCount);
-    memoryMessages = sliced.length > 0 ? sliced : undefined;
+    const history = getRoutingHistory(projectId, conversationId, memoryCount);
+    previousDecisions = history.length > 0 ? history : undefined;
   }
 
-  const userMessage = buildUserMessage(request, memoryMessages, maxUserMessageChars);
+  const userMessage = buildUserMessage(request, previousDecisions, maxUserMessageChars);
   const systemPrompt = buildSystemPrompt(
     candidates.map(c => ({
       id: c.model.id as string,

--- a/packages/service/src/routing/policies/types.ts
+++ b/packages/service/src/routing/policies/types.ts
@@ -41,6 +41,8 @@ export interface PolicyInput {
   token?: ProjectToken;
   /** ID della traccia corrente, da propagare alle chiamate LLM interne alla policy */
   traceId?: string;
+  /** ID della conversazione (da header x-routerly-conversation-id), usato per recuperare le decisioni di routing precedenti */
+  conversationId?: string;
 }
 
 /** Output standard restituito da ogni policy */

--- a/packages/service/src/routing/router.ts
+++ b/packages/service/src/routing/router.ts
@@ -113,7 +113,7 @@ export async function routeRequest(
 
   if (excludedByLimits.length > 0) {
     for (const exc of excludedByLimits) {
-      log?.debug(
+      log?.info(
         {
           modelId: exc.modelId,
           violated: exc.violated.map(v => ({
@@ -159,7 +159,7 @@ export async function routeRequest(
   if (validCandidates.length === 1) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const only = validCandidates[0]!;
-    log?.debug(
+    log?.info(
       { modelId: only.model.id, totalCandidates: candidates.length },
       'routing: single valid model — bypassing policies, forwarding directly',
     );
@@ -184,7 +184,7 @@ export async function routeRequest(
     policiesWithWeight.map(async ({ type, weight, config }) => {
       const fn = POLICY_MAP[type];
       if (!fn) {
-        log?.debug({ type }, 'routing: unknown policy type, skipping');
+        log?.info({ type }, 'routing: unknown policy type, skipping');
         return { type, weight, routing: [] as { model: string; point: number }[], excludes: [] as string[], failed: true };
       }
       try {
@@ -192,7 +192,7 @@ export async function routeRequest(
         return { type, weight, routing: out.routing, excludes: out.excludes ?? [], failed: false };
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
-        log?.debug({ type, err: errMsg }, 'routing: policy failed');
+        log?.info({ type, err: errMsg }, 'routing: policy failed');
         emit?.(te('router-response', `policy:error:${type}`, { type, error: errMsg }));
         return { type, weight, routing: [] as { model: string; point: number }[], excludes: [] as string[], failed: true };
       }
@@ -227,7 +227,7 @@ export async function routeRequest(
   }
 
   if (policyExcludes.size > 0) {
-    log?.debug(
+    log?.info(
       { excluded: Object.fromEntries(excludeReasons) },
       'routing: models excluded by policies',
     );
@@ -280,7 +280,7 @@ export async function routeRequest(
   }
 
   if (abstainedPolicies.length > 0) {
-    log?.debug({ abstained: abstainedPolicies }, 'routing: policies abstained (no discriminating signal)');
+    log?.info({ abstained: abstainedPolicies }, 'routing: policies abstained (no discriminating signal)');
     emit?.(te('router-response', 'router:abstained', { policies: abstainedPolicies }));
   }
 
@@ -302,7 +302,7 @@ export async function routeRequest(
   const tiedWinners = finalCandidates.filter(c => Math.abs(c.weight - topScore) < TIED_TOLERANCE);
   const hasTie = tiedWinners.length > 1;
 
-  log?.debug(
+  log?.info(
     {
       policies: successfulResults.map(r => ({
         type: r.type,

--- a/packages/service/src/routing/router.ts
+++ b/packages/service/src/routing/router.ts
@@ -49,6 +49,7 @@ export async function routeRequest(
   emit?: (entry: TraceEntry) => void,
   token?: ProjectToken,
   traceId?: string,
+  conversationId?: string,
 ): Promise<RouteResult> {
   const enabledPolicies = (project.policies ?? []).filter(p => p.enabled);
 
@@ -67,12 +68,28 @@ export async function routeRequest(
 
   // Carica i ModelConfig completi per i modelli associati al progetto
   const allModels: ModelConfig[] = await readConfig('models');
+  const missingModelIds: string[] = [];
   const candidates: CandidateModel[] = project.models
     .map(ref => {
       const model = allModels.find(m => m.id === ref.modelId);
-      return model ? { model, ...(ref.prompt !== undefined ? { prompt: ref.prompt } : {}), ...(ref.thresholds !== undefined ? { thresholds: ref.thresholds } : {}) } : null;
+      if (!model) {
+        missingModelIds.push(ref.modelId);
+        return null;
+      }
+      return { model, ...(ref.prompt !== undefined ? { prompt: ref.prompt } : {}), ...(ref.thresholds !== undefined ? { thresholds: ref.thresholds } : {}) };
     })
     .filter((m): m is NonNullable<typeof m> => m !== null);
+
+  if (missingModelIds.length > 0) {
+    log?.warn(
+      { projectId: project.id, missingModelIds },
+      'routing: project references models not found in registry',
+    );
+  }
+
+  if (candidates.length === 0) {
+    throw new Error(`no_models_available: project has no resolvable models (referenced: [${project.models.map(m => m.modelId).join(', ')}])`);
+  }
 
   // ── Pre-filtro limiti ────────────────────────────────────────────────────
   // Esclude i modelli che hanno già superato uno o più limiti prima di
@@ -171,7 +188,7 @@ export async function routeRequest(
         return { type, weight, routing: [] as { model: string; point: number }[], excludes: [] as string[], failed: true };
       }
       try {
-        const out = await fn({ request, candidates: validCandidates, config, ...(log !== undefined ? { log } : {}), ...(emit !== undefined ? { emit } : {}), projectId: project.id, ...(token !== undefined ? { token } : {}), ...(traceId !== undefined ? { traceId } : {}) });
+        const out = await fn({ request, candidates: validCandidates, config, ...(log !== undefined ? { log } : {}), ...(emit !== undefined ? { emit } : {}), projectId: project.id, ...(token !== undefined ? { token } : {}), ...(traceId !== undefined ? { traceId } : {}), ...(conversationId !== undefined ? { conversationId } : {}) });
         return { type, weight, routing: out.routing, excludes: out.excludes ?? [], failed: false };
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);

--- a/packages/service/src/routing/router.ts
+++ b/packages/service/src/routing/router.ts
@@ -96,7 +96,7 @@ export async function routeRequest(
 
   if (excludedByLimits.length > 0) {
     for (const exc of excludedByLimits) {
-      log?.info(
+      log?.debug(
         {
           modelId: exc.modelId,
           violated: exc.violated.map(v => ({
@@ -142,7 +142,7 @@ export async function routeRequest(
   if (validCandidates.length === 1) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const only = validCandidates[0]!;
-    log?.info(
+    log?.debug(
       { modelId: only.model.id, totalCandidates: candidates.length },
       'routing: single valid model — bypassing policies, forwarding directly',
     );
@@ -167,7 +167,7 @@ export async function routeRequest(
     policiesWithWeight.map(async ({ type, weight, config }) => {
       const fn = POLICY_MAP[type];
       if (!fn) {
-        log?.info({ type }, 'routing: unknown policy type, skipping');
+        log?.debug({ type }, 'routing: unknown policy type, skipping');
         return { type, weight, routing: [] as { model: string; point: number }[], excludes: [] as string[], failed: true };
       }
       try {
@@ -175,7 +175,7 @@ export async function routeRequest(
         return { type, weight, routing: out.routing, excludes: out.excludes ?? [], failed: false };
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
-        log?.info({ type, err: errMsg }, 'routing: policy failed');
+        log?.debug({ type, err: errMsg }, 'routing: policy failed');
         emit?.(te('router-response', `policy:error:${type}`, { type, error: errMsg }));
         return { type, weight, routing: [] as { model: string; point: number }[], excludes: [] as string[], failed: true };
       }
@@ -210,7 +210,7 @@ export async function routeRequest(
   }
 
   if (policyExcludes.size > 0) {
-    log?.info(
+    log?.debug(
       { excluded: Object.fromEntries(excludeReasons) },
       'routing: models excluded by policies',
     );
@@ -263,7 +263,7 @@ export async function routeRequest(
   }
 
   if (abstainedPolicies.length > 0) {
-    log?.info({ abstained: abstainedPolicies }, 'routing: policies abstained (no discriminating signal)');
+    log?.debug({ abstained: abstainedPolicies }, 'routing: policies abstained (no discriminating signal)');
     emit?.(te('router-response', 'router:abstained', { policies: abstainedPolicies }));
   }
 
@@ -285,7 +285,7 @@ export async function routeRequest(
   const tiedWinners = finalCandidates.filter(c => Math.abs(c.weight - topScore) < TIED_TOLERANCE);
   const hasTie = tiedWinners.length > 1;
 
-  log?.info(
+  log?.debug(
     {
       policies: successfulResults.map(r => ({
         type: r.type,

--- a/packages/service/src/routing/routingMemoryStore.ts
+++ b/packages/service/src/routing/routingMemoryStore.ts
@@ -1,0 +1,38 @@
+/**
+ * In-memory store for per-conversation routing decisions.
+ * Keyed by `${projectId}:${conversationId}` to avoid cross-project collisions.
+ * Entries expire after MAX_AGE_MS.
+ */
+
+export interface RoutingMemoryEntry {
+  model: string;
+  ts: number;
+}
+
+const MAX_AGE_MS = 60 * 60 * 1_000; // 1 hour
+const MAX_ENTRIES_PER_CONV = 50;
+
+const store = new Map<string, RoutingMemoryEntry[]>();
+
+function cleanup(): void {
+  const cutoff = Date.now() - MAX_AGE_MS;
+  for (const [id, entries] of store) {
+    const filtered = entries.filter(e => e.ts >= cutoff);
+    if (filtered.length === 0) store.delete(id);
+    else store.set(id, filtered);
+  }
+}
+
+export function addRoutingDecision(projectId: string, conversationId: string, model: string): void {
+  cleanup();
+  const key = `${projectId}:${conversationId}`;
+  const existing = store.get(key) ?? [];
+  existing.push({ model, ts: Date.now() });
+  if (existing.length > MAX_ENTRIES_PER_CONV) existing.splice(0, existing.length - MAX_ENTRIES_PER_CONV);
+  store.set(key, existing);
+}
+
+export function getRoutingHistory(projectId: string, conversationId: string, count: number): RoutingMemoryEntry[] {
+  const key = `${projectId}:${conversationId}`;
+  return (store.get(key) ?? []).slice(-count);
+}

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -22,6 +22,7 @@ export async function buildServer() {
         ? { transport: { target: 'pino-pretty', options: { colorize: true } } }
         : {}),
     },
+    disableRequestLogging: true,
     bodyLimit: 256 * 1024 * 1024, // 256 MB — support large files, vision, and 2M-token contexts
   });
 

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -100,6 +100,12 @@ export interface ModelConfig {
   endpoint: string;
   /** Provider API key (stored in plaintext; file permissions protect it) */
   apiKey?: string | undefined;
+  /**
+   * The exact model identifier sent to the upstream provider API.
+   * Used by the custom adapter to decouple the Routerly ID from the upstream model name.
+   * If absent, the adapter falls back to stripping the provider prefix from `id`.
+   */
+  upstreamModelId?: string;
   cost: TokenCost;
   /** Maximum context window size in tokens */
   contextWindow?: number;

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -362,4 +362,14 @@ export interface UsageRecord {
   callType?: CallType;
   /** Full trace captured at tracking time (router + model call events) */
   trace?: TraceEntry[];
+  /** Request trace ID (matches x-routerly-trace-id response header) */
+  traceId?: string;
+  /** Cost breakdown: input tokens cost in USD (includes cached + cache-write) */
+  costInput?: number;
+  /** Cost breakdown: output tokens cost in USD */
+  costOutput?: number;
+  /** Price per 1M input tokens in USD (from model config at call time) */
+  priceInput?: number;
+  /** Price per 1M output tokens in USD (from model config at call time) */
+  priceOutput?: number;
 }


### PR DESCRIPTION
## Modifiche

- **Preset temporali recenti**: aggiunta sezione "Recenti" nel DateRangePicker con 9 preset (1/3/5/10/15/30 min, 1/6/12 ore) che usano sliding window
- **Time picker per range custom**: due input orario (HH:MM:SS) sotto il calendario con default 00:00:00-23:59:59, modificabili dall'utente
- **Paginazione server-side**: parametri `page`/`pageSize` nel backend (default 50, max 200) con risposta `pagination` object
- **Parsing datetime condizionale**: il backend preserva la precisione ISO datetime per stringhe con orario, normalizza solo per date pure
- **UI paginazione**: controlli Precedente/Successiva con info pagina e totale record su UsagePage e ProjectLogsTab

## File modificati

- `packages/service/src/routes/api.ts` - backend pagination + datetime parsing
- `packages/dashboard/src/api.ts` - tipi e parametri API
- `packages/dashboard/src/components/DateRangePicker.tsx` - preset recenti + time picker
- `packages/dashboard/src/pages/UsagePage.tsx` - paginazione + logica preset recenti
- `packages/dashboard/src/pages/project/ProjectLogsTab.tsx` - stessa paginazione
