### PR TITLE
docs(0.2.0): document update channels, CLI update command, software update UI

### DIFF
--- a/website/versioned_docs/version-0.2.0/api/management.md
+++ b/website/versioned_docs/version-0.2.0/api/management.md
@@ -443,12 +443,72 @@ Returns `200 OK` on success or an error with details.
 GET /api/system/info
 ```
 
+No authentication required.
+
 **Response:**
 ```json
 {
-  "version": "1.2.3",
-  "uptime": 3600,
-  "node": "v22.0.0",
-  "platform": "darwin/arm64"
+  "version": "0.2.0",
+  "nodeVersion": "v22.0.0",
+  "platform": "darwin",
+  "configDir": "/Users/you/.routerly/config",
+  "dataDir": "/Users/you/.routerly/data",
+  "uptimeSeconds": 3600,
+  "channel": "stable",
+  "isDocker": false,
+  "updateInfo": {
+    "available": true,
+    "currentVersion": "0.2.0",
+    "latestVersion": "0.3.0",
+    "channel": "stable",
+    "releaseUrl": "https://github.com/Inebrio/Routerly/releases/tag/v0.3.0",
+    "checkedAt": "2026-06-09T10:00:00.000Z"
+  }
 }
 ```
+
+`updateInfo` is `null` if no check has completed yet (first 24 hours after boot). `isDocker` is `true` when the service is running inside a Docker container.
+
+---
+
+### Force Update Check
+
+```
+GET /api/system/update-check
+```
+
+Requires authentication. Forces an immediate check against the GitHub Releases API and returns the result. This also updates the cached value returned by `GET /api/system/info`.
+
+**Response:** same shape as `updateInfo` above (`UpdateInfo` object).
+
+```json
+{
+  "available": false,
+  "currentVersion": "0.2.0",
+  "latestVersion": "0.2.0",
+  "channel": "stable",
+  "checkedAt": "2026-06-09T12:34:56.000Z"
+}
+```
+
+---
+
+### Trigger In-App Update
+
+```
+POST /api/system/update
+```
+
+**Admin only.** Downloads and installs the latest version on the active channel and restarts the service. The response is returned immediately (202); the update runs in the background.
+
+**Constraints:**
+- Returns `403` if the caller is not an admin.
+- Returns `403` if the service is running inside Docker (`ROUTERLY_DOCKER=1`). Pull the new image instead.
+- Returns `400` if the service is running on Windows. Run the installer manually.
+
+**Response `202`:**
+```json
+{ "message": "Update started. The service will restart shortly." }
+```
+
+Poll `GET /health` to detect when the service has restarted. The CLI command `routerly update run` does this automatically.

--- a/website/versioned_docs/version-0.2.0/cli/commands.md
+++ b/website/versioned_docs/version-0.2.0/cli/commands.md
@@ -422,6 +422,86 @@ routerly service configure [options]
 
 ---
 
+## `routerly update`
+
+Manage Routerly version channels and trigger in-app updates.
+
+### `routerly update check`
+
+Check whether a newer version is available on the current channel.
+
+```
+routerly update check [--json]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Print output as JSON for scripting |
+
+Prints the current version, the latest version available on the active channel, and when the last check was performed. Exit code `0` in all cases (use `--json` and parse `available` for scripting).
+
+```bash
+routerly update check
+#   Routerly v0.2.0 is up to date.
+#   Channel: stable   Checked: 6/9/2026, 10:00:00 AM
+
+routerly update check --json
+```
+
+### `routerly update channel [name]`
+
+Show or change the update channel.
+
+```
+routerly update channel [name]
+```
+
+With no argument, prints the current channel. With an argument, updates the channel immediately — the running service is notified without a restart.
+
+Valid values:
+
+| Value | Description |
+|-------|-------------|
+| `latest` | Most recent release (may include pre-releases) |
+| `stable` | Most recent production-stable release |
+| `develop` | Development pre-release builds |
+| `vX.Y.Z` | Pin to a specific version tag (e.g. `v0.2.0`) |
+
+```bash
+routerly update channel           # show current channel
+routerly update channel latest    # switch to latest
+routerly update channel stable    # switch to stable
+routerly update channel develop   # switch to develop (pre-releases)
+routerly update channel v0.2.0    # pin to a specific version
+```
+
+Changing the channel to a version tag sets the channel to `custom` internally and disables automatic update notifications for that version.
+
+### `routerly update run`
+
+Trigger an in-app update to the newest version on the current channel.
+
+```
+routerly update run [--yes]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--yes` | Skip the interactive confirmation prompt |
+
+The service downloads and installs the update in the background, then restarts automatically. The CLI polls `/health` for up to 60 seconds and prints a confirmation when the service comes back online.
+
+```bash
+routerly update run          # interactive confirmation
+routerly update run --yes    # non-interactive (for scripts)
+```
+
+:::note Requirements
+Admin role required. Not available inside Docker containers — pull the new image and recreate the container instead. Not available on Windows — run the installer script manually.
+:::
+
+---
+
 ## `routerly status`
 
 ```

--- a/website/versioned_docs/version-0.2.0/dashboard/settings.md
+++ b/website/versioned_docs/version-0.2.0/dashboard/settings.md
@@ -54,12 +54,67 @@ Click the **Delete** icon next to a channel.
 
 ## About Tab
 
-Read-only system information:
+### Application
+
+System information about the running instance:
 
 | Field | Description |
 |-------|-------------|
 | **Version** | Routerly version string |
+| **Channel** | Active update channel: `latest`, `stable`, `develop`, or a pinned version tag. Editable — see [Update Channel](#update-channel) below |
 | **Uptime** | How long the service has been running since last start |
 | **Node.js** | Node.js runtime version |
 | **Platform** | OS and architecture |
 | **Config Directory** | Path to `~/.routerly/config/` (or `$ROUTERLY_HOME/config/`) |
+
+### Update Channel
+
+The channel selector lets you choose which release stream Routerly follows when checking for updates:
+
+| Channel | Description |
+|---------|-------------|
+| `latest` | Most recent release (may include pre-releases) |
+| `stable` | Most recent production-stable release |
+| `develop` | Development pre-release builds |
+| Custom version | Pin to a specific release tag (e.g. `v0.2.0`) |
+
+Changing the channel takes effect immediately — the running service is notified without a restart.
+
+To enter a specific version tag, select **Custom…** in the dropdown. Type the tag (e.g. `v0.2.0`) and click **Apply**.
+
+You can also change the channel from the CLI:
+
+```bash
+routerly update channel stable
+routerly update channel v0.2.0
+```
+
+### Software Update
+
+Shows the current update status for the active channel. The service checks for new releases automatically every 24 hours.
+
+| Field | Description |
+|-------|-------------|
+| **Current version** | The version currently running |
+| **Available version** | The latest version on the active channel, or "Up to date" if already current |
+| **Last checked** | Timestamp of the most recent check against the GitHub Releases API |
+
+**Check for updates** forces an immediate check against the GitHub Releases API and refreshes the displayed result.
+
+**Update to vX.Y.Z** — visible only when a newer version is available on the current channel and the service is not running inside Docker. Clicking it triggers an in-app update:
+
+1. The service downloads and runs the installer for the new version in the background
+2. The service restarts automatically
+3. The dashboard reloads once the service is back online (polled every 3 seconds, up to 60 seconds)
+
+:::note Docker deployments
+In-app update is disabled when Routerly is running inside a Docker container. Pull the new image and recreate the container instead:
+```bash
+docker pull inebrio/routerly:latest
+docker compose up -d
+```
+:::
+
+### Admin Update Banner
+
+When a newer version is available on the active channel, a yellow banner appears at the top of every page for admin users. The banner links to this page and can be dismissed for the current browser session by clicking **×**.

--- a/website/versioned_docs/version-0.2.0/getting-started/installation.md
+++ b/website/versioned_docs/version-0.2.0/getting-started/installation.md
@@ -37,6 +37,21 @@ curl -fsSL https://www.routerly.ai/install.sh | bash -s -- \
   --public-url https://routerly.example.com  # External URL of the service
   --no-service              # Skip service installation (CLI only)
   --no-daemon               # Skip auto-start setup
+  --channel stable          # Update channel: latest | stable | develop (default: stable)
+  --version v0.2.0          # Install a specific version tag (overrides --channel)
+```
+
+By default, the installer fetches the **`stable`** channel — the latest production-ready release. Use `--channel latest` to get the most recent release (including pre-releases), or `--version vX.Y.Z` to pin an exact version.
+
+```bash
+# Install the stable release (default)
+curl -fsSL https://www.routerly.ai/install.sh | bash
+
+# Install the latest release
+curl -fsSL https://www.routerly.ai/install.sh | bash -s -- --channel latest
+
+# Install a specific version
+curl -fsSL https://www.routerly.ai/install.sh | bash -s -- --version v0.2.0
 ```
 
 #### Installation scopes
@@ -64,10 +79,20 @@ Regardless of scope, each user's CLI credentials (JWT tokens, refresh tokens) ar
 ### Windows
 
 ```powershell
+# Stable release (default)
 powershell -c "irm https://www.routerly.ai/install.ps1 | iex"
+
+# Specific channel or version
+powershell -c "& ([scriptblock]::Create((irm https://www.routerly.ai/install.ps1))) -Channel latest"
+powershell -c "& ([scriptblock]::Create((irm https://www.routerly.ai/install.ps1))) -Version v0.2.0"
 ```
 
 This installs Routerly as a Windows Service and adds the CLI to your PATH.
+
+| Parameter | Description |
+|-----------|-------------|
+| `-Channel` | `latest` \| `stable` \| `develop` (default: `stable`) |
+| `-Version` | Specific version tag, e.g. `v0.2.0` (overrides `-Channel`) |
 
 ---
 

--- a/website/versioned_docs/version-0.2.0/reference/config-files.md
+++ b/website/versioned_docs/version-0.2.0/reference/config-files.md
@@ -76,6 +76,7 @@ Global service configuration.
   "defaultTimeoutMs": 30000,
   "logLevel": "info",
   "publicUrl": "http://localhost:3000",
+  "channel": "stable",
   "notifications": []
 }
 ```
@@ -88,6 +89,7 @@ Global service configuration.
 | `defaultTimeoutMs` | `number` | `30000` | Default provider request timeout in milliseconds |
 | `logLevel` | `string` | `"info"` | Log verbosity: `"error"`, `"warn"`, `"info"`, `"debug"` |
 | `publicUrl` | `string` | `"http://localhost:3000"` | Externally reachable URL, used for notification links |
+| `channel` | `string` | `"stable"` | Update channel: `"latest"`, `"stable"`, `"develop"`, or a version tag such as `"v0.2.0"`. Controls which GitHub Release the update checker compares against |
 | `notifications` | `array` | `[]` | Notification channel configurations — see [Notifications](../concepts/notifications.md) |
 
 ---


### PR DESCRIPTION
## Summary

Updates `versioned_docs/version-0.2.0/` with the new features introduced in v0.2.0.

**`cli/commands.md`** — new `routerly update` command group:
- `update check [--json]`: check for newer version on current channel
- `update channel [name]`: show or change the update channel (latest/stable/develop/vX.Y.Z)
- `update run [--yes]`: trigger in-app update with health polling; Docker/Windows constraints documented

**`dashboard/settings.md`** — expanded About tab:
- Channel selector (interactive, saves without restart)
- Software Update section (current/available version, last checked, Check/Update buttons)
- Admin dismissible banner description
- Docker note for in-app update

**`api/management.md`** — System section:
- `GET /api/system/info`: expanded response with `channel`, `isDocker`, `updateInfo`
- `GET /api/system/update-check` (new): force check, returns UpdateInfo
- `POST /api/system/update` (new): admin-only, 403 Docker, 400 Windows, returns 202

**`reference/config-files.md`** — `settings.json`:
- Added `channel` field (`"stable"` default) with description

**`getting-started/installation.md`** — installer flags:
- `--channel` and `--version` flags for `install.sh`
- `-Channel` and `-Version` parameters for `install.ps1`
- Examples for stable (default), latest, and pinned version

## Test plan

- [x] `npm run build` in `website/` → no errors, no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)