### PR TITLE
docs(config): set 0.1.5 as default docs version

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -45,6 +45,17 @@ const config: Config = {
           routeBasePath: '/',
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/Inebrio/Routerly/edit/main/',
+          lastVersion: '0.1.5',
+          versions: {
+            '0.1.5': {
+              label: '0.1.5 (stable)',
+              badge: true,
+            },
+            '0.2.0': {
+              label: '0.2.0',
+              badge: true,
+            },
+          },
         },
         blog: false,
         theme: {


### PR DESCRIPTION
Sets `lastVersion: '0.1.5'` in `docusaurus.config.ts` so the stable docs are served at the root URL. v0.2.0 is accessible from the version dropdown.

Labels: `0.1.5 (stable)` · `0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)