### PR TITLE
docs(0.2.0): add channel/version references to intro, quick-start, configuration

### DIFF
--- a/website/versioned_docs/version-0.2.0/getting-started/configuration.md
+++ b/website/versioned_docs/version-0.2.0/getting-started/configuration.md
@@ -61,6 +61,7 @@ Open **Settings → General** in the dashboard. Changes take effect immediately 
 | `defaultTimeoutMs` | `30000` | Per-request timeout in milliseconds |
 | `logLevel` | `"info"` | Log verbosity: `trace` / `debug` / `info` / `warn` / `error` |
 | `publicUrl` | `"http://localhost:3000"` | External URL shown in the dashboard connection snippets |
+| `channel` | `"stable"` | Update channel: `"stable"`, `"latest"`, `"develop"`, or a version tag (e.g. `"v0.2.0"`). Editable from the dashboard or via `routerly update channel` |
 | `notifications` | `[]` | Array of notification channel configurations |
 
 ---
@@ -73,6 +74,7 @@ Open **Settings → General** in the dashboard. Changes take effect immediately 
 | `ROUTERLY_PORT` | Service port (overrides `settings.json`) |
 | `ROUTERLY_SCOPE` | Installation scope: `user` or `system` |
 | `ROUTERLY_PUBLIC_URL` | External URL of the service |
+| `ROUTERLY_DOCKER` | Set to `1` by the official Docker image. Disables in-app update (`POST /api/system/update`) |
 | `NODE_ENV` | Set to `production` to disable pretty-printed logs |
 
 ---

--- a/website/versioned_docs/version-0.2.0/getting-started/quick-start.md
+++ b/website/versioned_docs/version-0.2.0/getting-started/quick-start.md
@@ -12,11 +12,21 @@ From zero to your first routed AI response in under 5 minutes.
 ## Step 1: Install Routerly
 
 ```bash
-# macOS / Linux
+# macOS / Linux — installs the stable release
 curl -fsSL https://www.routerly.ai/install.sh | bash
 
-# Windows (PowerShell)
+# Windows (PowerShell) — installs the stable release
 powershell -c "irm https://www.routerly.ai/install.ps1 | iex"
+```
+
+The installer defaults to the **`stable`** channel — the latest production-ready release. To install a different channel or a specific version:
+
+```bash
+# Latest release (may include pre-releases)
+curl -fsSL https://www.routerly.ai/install.sh | bash -s -- --channel latest
+
+# Pin to a specific version
+curl -fsSL https://www.routerly.ai/install.sh | bash -s -- --version v0.2.0
 ```
 
 After the installer finishes, start the service if it isn't already running:

--- a/website/versioned_docs/version-0.2.0/intro.md
+++ b/website/versioned_docs/version-0.2.0/intro.md
@@ -28,6 +28,7 @@ Routerly is a self-hosted LLM API gateway with intelligent routing, cost trackin
 | **Admin CLI** | Full management from the terminal with `routerly` commands |
 | **RBAC** | Role-based access control with 7 granular permissions and custom roles |
 | **Notifications** | Email and webhook alerts via SMTP, SES, SendGrid, Azure, Google, or custom webhook |
+| **Self-updating** | Built-in update checker polls GitHub Releases every 24 h. Channels: `stable`, `latest`, `develop`. One-click update from the dashboard or `routerly update run` |
 
 ---
 
@@ -73,13 +74,21 @@ LangChain   completions   Track cost     ◀──  ...
 **macOS / Linux:**
 
 ```bash
+# Install stable release (default)
 curl -fsSL https://www.routerly.ai/install.sh | bash
+
+# Install latest release
+curl -fsSL https://www.routerly.ai/install.sh | bash -s -- --channel latest
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
+# Install stable release (default)
 powershell -c "irm https://www.routerly.ai/install.ps1 | iex"
+
+# Install latest release
+powershell -c "& ([scriptblock]::Create((irm https://www.routerly.ai/install.ps1))) -Channel latest"
 ```
 
 Then register a model, create a project, and start:


### PR DESCRIPTION
Completes v0.2.0 docs update with references to channels and install flags in the top-level pages.

- **intro.md**: "Self-updating" row in Key Features; stable/latest install commands in Quick Start section
- **quick-start.md**: Step 1 notes stable default, shows `--channel` and `--version` flags
- **configuration.md**: `channel` field in settings reference table; `ROUTERLY_DOCKER` in env vars table

🤖 Generated with [Claude Code](https://claude.com/claude-code)