### PR TITLE
feat(telemetry): opt-in anonymous install metrics

### DIFF
--- a/.changeset/release-0-2-0.md
+++ b/.changeset/release-0-2-0.md
@@ -30,6 +30,23 @@ Added built-in support for: DeepSeek, Groq, Together AI, and Perplexity. Pricing
 **Decoupled model IDs**
 The Routerly model ID is now independent of the upstream provider API model name. This enables cleaner aliases and model renaming without breaking existing configurations.
 
+**Built-in update checker**
+Routerly now polls GitHub Releases every 24 hours and compares the running version against the configured channel (`latest`, `current`, `develop`, or a pinned tag). The result is cached in memory and surfaced via the dashboard and CLI.
+
+**CLI update commands**
+Three new subcommands under `routerly update`:
+- `routerly update check` — show whether a newer version is available on the active channel
+- `routerly update channel [name]` — get or set the update channel
+- `routerly update run` — download and install the latest version (non-Docker only)
+
+**Software Update section in the dashboard**
+The Settings → About tab now shows the current channel, the latest available version, the last-checked timestamp, and a one-click update button. The channel selector is populated dynamically from GitHub Releases and always includes the base channels.
+
+**New management API endpoints**
+- `GET /api/system/update-check` — trigger an immediate update check and return the result
+- `POST /api/system/update` — run the in-app updater (admin only; disabled in Docker)
+- `GET /api/system/releases` — list available channels and version tags from GitHub Releases
+
 **Improved dashboard UX**
 - Policy editor: add/remove policies with a searchable select
 - Usage page: time-based filtering and pagination

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -1,0 +1,138 @@
+---
+title: Anonymous Telemetry
+sidebar_position: 4
+---
+
+# Anonymous Telemetry
+
+Routerly **never** sends any data automatically. Telemetry is strictly opt-in: nothing leaves your machine until you explicitly say yes, either during installation or from the dashboard/CLI at any time.
+
+This page documents exactly what is sent, when, and why — so you can make an informed decision.
+
+---
+
+## Why telemetry exists
+
+Routerly is self-hosted. That means we have no way to know how many instances are running, whether people are updating, or whether the installer works on different platforms — unless someone tells us.
+
+The data collected helps answer one question: **is Routerly being used, and are upgrades reaching people?** That's it. No usage patterns, no model calls, no cost data, nothing about your workload.
+
+---
+
+## What is sent
+
+A single HTTP `POST` request to `https://telemetry.routerly.ai/ping` with this JSON body:
+
+```json
+{
+  "event":     "install",
+  "version":   "0.2.0",
+  "platform":  "linux",
+  "installId": "a3f1c8b2d4e6..."
+}
+```
+
+| Field | Type | Example | Description |
+|-------|------|---------|-------------|
+| `event` | string | `install` | One of `install`, `upgrade`, or `uninstall` |
+| `version` | string | `0.2.0` | Routerly version being installed or running |
+| `platform` | string | `linux` | OS platform: `linux`, `darwin`, or `win32` |
+| `installId` | string | `a3f1c8b2...` | Random hex ID generated once at opt-in time |
+
+**Nothing else is sent.** No hostname, no IP address logged server-side, no email, no project names, no model IDs, no usage data, no tokens.
+
+The `installId` is a random string generated locally the moment you opt in. It has no relation to your identity — it exists only to deduplicate counts (so a single instance upgrading ten times is counted as one installation, not ten).
+
+---
+
+## When events are sent
+
+| Event | When |
+|-------|------|
+| `install` | Once, after you answer "yes" to the consent prompt during a fresh installation, or after clicking "Yes, help out" in the dashboard banner |
+| `upgrade` | Once per upgrade run, if you had previously opted in |
+| `uninstall` | Once, just before the uninstaller removes your files, if you had previously opted in |
+
+Events are fire-and-forget with a 3-second timeout. If the request fails (network error, server down), Routerly continues normally — no retry, no error.
+
+---
+
+## What is NOT sent
+
+- LLM requests, prompts, or completions
+- Token counts or cost data
+- Project names, model IDs, or API keys
+- User email addresses or any account information
+- Hostname, IP address, or any network identifier
+- Usage statistics or performance metrics
+- Anything from your `~/.routerly/` config directory
+
+---
+
+## Opt in
+
+**During installation** — the installer asks once at the end:
+
+```
+Help improve Routerly? (completely optional)
+Sends only: event type, version, platform, and a random ID.
+No personal data. No IP stored. Opt out anytime:
+  routerly telemetry off
+
+Send anonymous install metrics? (yes/[no]):
+```
+
+The default is **no**. You must type `yes` to enable it.
+
+**From the dashboard** — if you installed via Docker or another method that skipped the installer prompt, a one-time banner appears after your first login. Two explicit buttons: "Yes, help out" and "No thanks". Nothing is sent until you click one.
+
+**From the CLI** at any time:
+
+```bash
+routerly telemetry on     # opt in
+routerly telemetry off    # opt out
+routerly telemetry status # check current setting
+```
+
+---
+
+## Opt out
+
+You can opt out at any time, even after opting in:
+
+```bash
+routerly telemetry off
+```
+
+This sets `telemetry.enabled: false` in your `settings.json` and stops all future pings immediately. No further data is sent after this point.
+
+Telemetry is also automatically skipped when the environment variable `CI=true` is detected, so automated deployments and CI pipelines are never prompted and never send data.
+
+---
+
+## Where the setting is stored
+
+The preference is stored in your local `settings.json` file:
+
+```
+~/.routerly/config/settings.json
+```
+
+```json
+{
+  "telemetry": {
+    "enabled": true,
+    "installId": "a3f1c8b2d4e6..."
+  }
+}
+```
+
+If `telemetry` is absent from the file, Routerly has not asked you yet and no data has ever been sent.
+
+---
+
+## Server-side data handling
+
+The telemetry endpoint receives the four fields listed above. IP addresses are not logged. The data is used only to maintain aggregate counts of active installations, upgrade adoption, and uninstalls.
+
+No individual records are shared with third parties.

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -1,0 +1,78 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { api, ApiError } from '../api.js';
+import { getCurrentAccount } from '../store.js';
+import type { Settings } from '@routerly/shared';
+
+export function makeTelemetryCommand(): Command {
+  const cmd = new Command('telemetry').description('Manage anonymous install metrics');
+
+  cmd.command('status')
+    .description('Show current telemetry preference')
+    .action(async () => {
+      const account = await getCurrentAccount();
+      if (!account) {
+        console.log(chalk.yellow('Not logged in. Run: routerly auth login'));
+        return;
+      }
+      try {
+        const settings = await api<Settings>('GET', '/api/settings');
+        const t = settings.telemetry;
+        if (!t) {
+          console.log(chalk.dim('Telemetry: not configured (you have not been asked yet)'));
+        } else if (t.enabled) {
+          console.log(chalk.green('Telemetry: enabled') + chalk.dim(` (install ID: ${t.installId})`));
+        } else {
+          console.log(chalk.gray('Telemetry: disabled'));
+        }
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  cmd.command('on')
+    .description('Opt in to anonymous install metrics')
+    .action(async () => {
+      const account = await getCurrentAccount();
+      if (!account) {
+        console.log(chalk.yellow('Not logged in. Run: routerly auth login'));
+        return;
+      }
+      try {
+        await api<Settings>('PUT', '/api/settings', { telemetry: { enabled: true } });
+        console.log(chalk.green('✓ Anonymous metrics enabled. Thank you!'));
+        console.log(chalk.dim('  Sends only: event type, version, platform, and a random ID. No personal data.'));
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 401) {
+          console.error(chalk.red('Admin privileges required.'));
+        } else {
+          console.error(chalk.red(`Error: ${(err as Error).message}`));
+        }
+        process.exit(1);
+      }
+    });
+
+  cmd.command('off')
+    .description('Opt out of anonymous install metrics')
+    .action(async () => {
+      const account = await getCurrentAccount();
+      if (!account) {
+        console.log(chalk.yellow('Not logged in. Run: routerly auth login'));
+        return;
+      }
+      try {
+        await api<Settings>('PUT', '/api/settings', { telemetry: { enabled: false } });
+        console.log(chalk.green('✓ Anonymous metrics disabled.'));
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 401) {
+          console.error(chalk.red('Admin privileges required.'));
+        } else {
+          console.error(chalk.red(`Error: ${(err as Error).message}`));
+        }
+        process.exit(1);
+      }
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ import { makeReportCommand } from './commands/report.js';
 import { makeServiceCommand } from './commands/service.js';
 import { makeStatusCommand } from './commands/status.js';
 import { makeUpdateCommand } from './commands/update.js';
+import { makeTelemetryCommand } from './commands/telemetry.js';
 
 const program = new Command();
 
@@ -33,5 +34,6 @@ program.addCommand(makeRoleCommand());
 program.addCommand(makeReportCommand());
 program.addCommand(makeServiceCommand());
 program.addCommand(makeUpdateCommand());
+program.addCommand(makeTelemetryCommand());
 
 program.parse(process.argv);

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -240,7 +240,7 @@ function ProtectedLayout() {
               <strong>Routerly never sends data automatically.</strong>{' '}
               Would you like to help by sending anonymous install metrics? Only event type, version, platform, and a random ID — no personal data, no IP.{' '}
               <a
-                href="https://doc.routerly.ai/reference/telemetry"
+                href="https://doc.routerly.ai/next/reference/telemetry"
                 target="_blank"
                 rel="noopener noreferrer"
                 style={{ color: 'inherit', textDecoration: 'underline' }}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -27,7 +27,8 @@ import { SettingsGeneralTab, SettingsAboutTab, SettingsNotificationsTab } from '
 import { RolesPage } from './pages/RolesPage';
 import { ProfilePage } from './pages/ProfilePage';
 import { UserEditPage } from './pages/UserEditPage';
-import { LayoutDashboard, Cpu, FolderOpen, BarChart2, FlaskConical, Settings as SettingsIcon, UserCircle, LogOut, Sun, Moon, Monitor, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import { HelpPage } from './pages/HelpPage';
+import { LayoutDashboard, Cpu, FolderOpen, BarChart2, FlaskConical, HelpCircle, Settings as SettingsIcon, UserCircle, LogOut, Sun, Moon, Monitor, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import { Logo } from './components/Logo';
 
 const THEME_OPTIONS: { value: Theme; icon: ReactNode; label: string }[] = [
@@ -86,6 +87,7 @@ function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => 
     { to: '/dashboard/projects', icon: <FolderOpen size={17} />, label: 'Projects' },
     { to: '/dashboard/usage', icon: <BarChart2 size={17} />, label: 'Usage' },
     { to: '/dashboard/test', icon: <FlaskConical size={17} />, label: 'Test' },
+    { to: '/dashboard/help', icon: <HelpCircle size={17} />, label: 'Help' },
   ];
 
   return (
@@ -351,6 +353,7 @@ const router = createBrowserRouter([
               { path: 'about', element: <SettingsAboutTab /> },
             ],
           },
+          { path: 'help', element: <HelpPage /> },
           { path: 'profile', element: <ProfilePage /> },
           { path: 'usage/:id', element: <UsageRecordPage /> },
           { path: '*', element: <Navigate to="overview" replace /> },

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type ReactNode } from 'react';
 import { createBrowserRouter, RouterProvider, NavLink, Navigate, useNavigate, Outlet, Link } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 import { ThemeProvider, useTheme, type Theme } from './ThemeContext';
-import { checkSetupStatus, getSystemInfo } from './api';
+import { checkSetupStatus, getSystemInfo, getSettings, updateSettings } from './api';
 import type { UpdateInfo } from './api';
 import { LoginPage } from './pages/LoginPage';
 import { SetupPage } from './pages/SetupPage';
@@ -155,6 +155,7 @@ function ProtectedLayout() {
   const [bannerDismissed, setBannerDismissed] = useState(() => {
     return localStorage.getItem('lr-update-banner-dismissed') === 'true';
   });
+  const [telemetryUndecided, setTelemetryUndecided] = useState(false);
 
   useEffect(() => {
     getSystemInfo()
@@ -164,6 +165,13 @@ function ProtectedLayout() {
       })
       .catch(() => { /* non-critical */ });
   }, []);
+
+  useEffect(() => {
+    if (user?.role !== 'admin') return;
+    getSettings()
+      .then(s => { if (s.telemetry === undefined) setTelemetryUndecided(true); })
+      .catch(() => { /* non-critical */ });
+  }, [user]);
 
   function handleToggle() {
     setCollapsed(prev => {
@@ -178,7 +186,12 @@ function ProtectedLayout() {
     setBannerDismissed(true);
   }
 
-  const showBanner = !bannerDismissed && !isDocker && user?.role === 'admin' && updateInfo?.available;
+  function handleTelemetryChoice(enabled: boolean) {
+    setTelemetryUndecided(false);
+    updateSettings({ telemetry: { enabled } } as any).catch(() => { /* non-critical */ });
+  }
+
+  const showUpdateBanner = !bannerDismissed && !isDocker && user?.role === 'admin' && updateInfo?.available;
 
   if (isLoading) return <div className="loading-center"><div className="spinner" /></div>;
   if (!user) return <Navigate to="/dashboard/login" replace />;
@@ -186,7 +199,7 @@ function ProtectedLayout() {
     <div className={`app-shell${collapsed ? ' sidebar-collapsed' : ''}`}>
       <Sidebar collapsed={collapsed} onToggle={handleToggle} />
       <main className="main-content">
-        {showBanner && (
+        {showUpdateBanner && (
           <div style={{
             background: 'var(--warning-bg, #fffbeb)',
             borderBottom: '1px solid var(--warning-border, #f6e05e)',
@@ -209,6 +222,43 @@ function ProtectedLayout() {
               title="Dismiss"
             >
               ×
+            </button>
+          </div>
+        )}
+        {telemetryUndecided && (
+          <div style={{
+            background: 'var(--info-bg, #eff6ff)',
+            borderBottom: '1px solid var(--info-border, #bfdbfe)',
+            padding: '10px 20px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            fontSize: '0.85rem',
+            color: 'var(--info-text, #1e40af)',
+          }}>
+            <span style={{ flex: 1 }}>
+              <strong>Routerly never sends data automatically.</strong>{' '}
+              Would you like to help by sending anonymous install metrics? Only event type, version, platform, and a random ID — no personal data, no IP.{' '}
+              <a
+                href="https://doc.routerly.ai/reference/telemetry"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'inherit', textDecoration: 'underline' }}
+              >
+                What is sent?
+              </a>
+            </span>
+            <button
+              onClick={() => handleTelemetryChoice(true)}
+              style={{ padding: '4px 12px', borderRadius: 4, border: '1px solid currentColor', cursor: 'pointer', background: 'none', fontSize: '0.82rem', fontWeight: 600, color: 'inherit', whiteSpace: 'nowrap' }}
+            >
+              Yes, help out
+            </button>
+            <button
+              onClick={() => handleTelemetryChoice(false)}
+              style={{ padding: '4px 12px', borderRadius: 4, border: 'none', cursor: 'pointer', background: 'none', fontSize: '0.82rem', opacity: 0.7, color: 'inherit', whiteSpace: 'nowrap' }}
+            >
+              No thanks
             </button>
           </div>
         )}

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -359,6 +359,11 @@ export type AzureEmailConfig    = AzureChannelConfig;
 export type GoogleEmailConfig   = GoogleChannelConfig;
 export type EmailConfig = SmtpChannelConfig | SesChannelConfig | SendGridChannelConfig | AzureChannelConfig | GoogleChannelConfig;
 
+export interface TelemetryConfig {
+  enabled: boolean;
+  installId: string;
+}
+
 export interface Settings {
   port: number;
   host: string;
@@ -370,6 +375,8 @@ export interface Settings {
   notifications?: NotificationsConfig;
   /** Distribution channel for updates: 'latest' | 'stable' | 'develop' | vX.Y.Z tag */
   channel?: string;
+  /** Anonymous install metrics opt-in. Absent means the user has not been asked yet. */
+  telemetry?: TelemetryConfig;
 }
 
 export const getSettings = () => request<Settings>('/settings');

--- a/packages/dashboard/src/pages/HelpPage.tsx
+++ b/packages/dashboard/src/pages/HelpPage.tsx
@@ -1,0 +1,233 @@
+import { useState } from 'react';
+import { Bug, ExternalLink, Mail, ChevronDown, ChevronRight, MessageSquarePlus } from 'lucide-react';
+
+const FAQ_ITEMS = [
+  {
+    q: 'How do I connect my app to Routerly?',
+    a: `Point your OpenAI or Anthropic SDK to your Routerly instance. Replace the base URL with http://your-host:3000/v1 (OpenAI-compatible) or http://your-host:3000/anthropic (Anthropic-compatible), then use a project token as the API key. That's it — no other changes needed.`,
+  },
+  {
+    q: 'Is Routerly compatible with tools that use the OpenAI SDK?',
+    a: 'Yes. Routerly is a drop-in replacement: any tool that supports a custom base URL and API key (LangChain, LlamaIndex, Cursor, Continue, etc.) works out of the box. For Anthropic-format clients, use the /anthropic endpoint instead.',
+  },
+  {
+    q: 'How does model routing work?',
+    a: 'Each project has a routing policy that decides which model receives a request. Policies include round-robin, lowest cost, fastest response, fallback chains, and more. You configure them per project under Projects → Routing.',
+  },
+  {
+    q: 'How do I add a new AI model?',
+    a: 'Go to Models → Add model. You can add any OpenAI-compatible provider (Ollama, LM Studio, custom endpoints) or a native Anthropic endpoint. Fill in the base URL, API key, and model ID — Routerly will handle the rest.',
+  },
+  {
+    q: 'Is my data stored? Are my prompts logged?',
+    a: 'Routerly is self-hosted and stores data only on your machine (in ~/.routerly/ by default). Prompts and responses are never sent anywhere by Routerly. Request logs are stored locally and only if you enable them per-project.',
+  },
+  {
+    q: 'What\'s a project token and how is it different from a provider API key?',
+    a: 'A project token is a credential you give to your app or team members to authenticate with Routerly. It\'s separate from your provider API keys, which Routerly stores securely on the server side. Your apps never see the real provider keys.',
+  },
+];
+
+function FaqItem({ q, a }: { q: string; a: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{
+      borderBottom: '1px solid var(--border)',
+    }}>
+      <button
+        onClick={() => setOpen(v => !v)}
+        style={{
+          width: '100%',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          padding: '14px 0',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          textAlign: 'left',
+          color: 'var(--text-primary)',
+          fontSize: '0.88rem',
+          fontWeight: 500,
+        }}
+      >
+        <span style={{ color: 'var(--text-muted)', flexShrink: 0 }}>
+          {open ? <ChevronDown size={15} /> : <ChevronRight size={15} />}
+        </span>
+        {q}
+      </button>
+      {open && (
+        <p style={{
+          margin: '0 0 14px 25px',
+          fontSize: '0.84rem',
+          color: 'var(--text-secondary)',
+          lineHeight: 1.6,
+        }}>
+          {a}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function Card({ children, style }: { children: React.ReactNode; style?: React.CSSProperties }) {
+  return (
+    <div style={{
+      background: 'var(--bg-elevated)',
+      border: '1px solid var(--border)',
+      borderRadius: 10,
+      padding: '20px 24px',
+      ...style,
+    }}>
+      {children}
+    </div>
+  );
+}
+
+const ISSUE_TEMPLATE = `**What happened?**
+(Describe the problem in plain words)
+
+**Steps to reproduce**
+1.
+2.
+
+**Expected behaviour**
+(What you expected to see)
+
+**Routerly version**
+(Run \`routerly --version\` or check Settings → About)`;
+
+export function HelpPage() {
+  const [templateVisible, setTemplateVisible] = useState(false);
+
+  const issueUrl = `https://github.com/Inebrio/Routerly/issues/new?labels=bug&template=bug_report.md`;
+  const featureUrl = `https://github.com/Inebrio/Routerly/issues/new?labels=enhancement&template=feature_request.md`;
+
+  return (
+    <>
+      <div className="page-header">
+        <h1>Help &amp; Support</h1>
+        <p>We're here to help — find answers or reach out anytime.</p>
+      </div>
+
+      <div className="page-body" style={{ display: 'flex', flexDirection: 'column', gap: 20, maxWidth: 640 }}>
+
+        {/* ── GitHub Issues ──────────────────────────────────────────────────── */}
+        <Card>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+            <div style={{
+              width: 34, height: 34, borderRadius: 8,
+              background: 'rgba(61,117,245,0.12)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+            }}>
+              <Bug size={17} color="var(--accent)" />
+            </div>
+            <div>
+              <div style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--text-primary)' }}>Report a bug or suggest a feature</div>
+              <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', marginTop: 1 }}>Open a GitHub issue — it takes 2 minutes</div>
+            </div>
+          </div>
+
+          <p style={{ fontSize: '0.84rem', color: 'var(--text-secondary)', lineHeight: 1.6, margin: '0 0 14px' }}>
+            GitHub issues are the best way to report bugs or propose improvements. To help us fix things faster, include: what you did, what you expected to happen, and what actually happened.
+          </p>
+
+          <div style={{ marginBottom: 14 }}>
+            <button
+              onClick={() => setTemplateVisible(v => !v)}
+              style={{
+                background: 'none', border: 'none', cursor: 'pointer', padding: 0,
+                fontSize: '0.8rem', color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: 4,
+              }}
+            >
+              {templateVisible ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+              Show issue template
+            </button>
+            {templateVisible && (
+              <pre style={{
+                marginTop: 10,
+                background: 'var(--bg-base)',
+                border: '1px solid var(--border)',
+                borderRadius: 8,
+                padding: '12px 14px',
+                fontSize: '0.78rem',
+                color: 'var(--text-secondary)',
+                lineHeight: 1.6,
+                whiteSpace: 'pre-wrap',
+                fontFamily: 'var(--font-mono, monospace)',
+              }}>
+                {ISSUE_TEMPLATE}
+              </pre>
+            )}
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <a
+              href={issueUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn btn-primary btn-sm"
+              style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 6 }}
+            >
+              <ExternalLink size={13} /> Report a bug
+            </a>
+            <a
+              href={featureUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn btn-secondary btn-sm"
+              style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 6 }}
+            >
+              <MessageSquarePlus size={13} /> Request a feature
+            </a>
+          </div>
+        </Card>
+
+        {/* ── Email support ──────────────────────────────────────────────────── */}
+        <Card>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+            <div style={{
+              width: 34, height: 34, borderRadius: 8,
+              background: 'rgba(16,185,129,0.12)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+            }}>
+              <Mail size={17} color="#10b981" />
+            </div>
+            <div>
+              <div style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--text-primary)' }}>Contact support</div>
+              <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', marginTop: 1 }}>We read every message and reply as soon as we can</div>
+            </div>
+          </div>
+
+          <p style={{ fontSize: '0.84rem', color: 'var(--text-secondary)', lineHeight: 1.6, margin: '0 0 14px' }}>
+            For anything that doesn't fit a GitHub issue — billing questions, private concerns, or if you just want to say hi — drop us a line.
+          </p>
+
+          <a
+            href="mailto:support@routerly.ai"
+            className="btn btn-secondary btn-sm"
+            style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 6 }}
+          >
+            <Mail size={13} /> support@routerly.ai
+          </a>
+        </Card>
+
+        {/* ── FAQ ───────────────────────────────────────────────────────────── */}
+        <Card>
+          <div style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--text-primary)', marginBottom: 4 }}>
+            Frequently asked questions
+          </div>
+          <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', marginBottom: 16 }}>
+            Quick answers to the most common questions
+          </div>
+          <div>
+            {FAQ_ITEMS.map(item => (
+              <FaqItem key={item.q} q={item.q} a={item.a} />
+            ))}
+          </div>
+        </Card>
+
+      </div>
+    </>
+  );
+}

--- a/packages/dashboard/src/pages/SettingsPage.tsx
+++ b/packages/dashboard/src/pages/SettingsPage.tsx
@@ -44,7 +44,7 @@ function TelemetrySection({ settings, onSaved }: { settings: Settings; onSaved: 
         <p style={{ fontSize: '0.75rem', color: 'var(--text-muted)', margin: '0 0 12px' }}>
           When enabled, Routerly sends only: event type (install / upgrade / uninstall), version, platform, and a random ID.
           No personal data, no usage data, no IP stored.{' '}
-          <a href="https://doc.routerly.ai/reference/telemetry" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)', textDecoration: 'none' }}>
+          <a href="https://doc.routerly.ai/next/reference/telemetry" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)', textDecoration: 'none' }}>
             What is sent?
           </a>
         </p>

--- a/packages/dashboard/src/pages/SettingsPage.tsx
+++ b/packages/dashboard/src/pages/SettingsPage.tsx
@@ -1,10 +1,86 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Save, Plus, Trash2, Mail, Search, ChevronDown, ChevronRight, Globe } from 'lucide-react';
+import { Save, Plus, Trash2, Mail, Search, ChevronDown, ChevronRight, Globe, BarChart2 } from 'lucide-react';
 import { NavLink, Outlet, Navigate } from 'react-router-dom';
 import { getSettings, updateSettings, getSystemInfo, testNotificationChannel, checkForUpdates, triggerUpdate, getAvailableReleases } from '../api';
 import type { Settings, SystemInfo, UpdateInfo, AvailableReleases } from '../api';
 
 const LOG_LEVELS: Settings['logLevel'][] = ['trace', 'debug', 'info', 'warn', 'error'];
+
+// ── Telemetry section (self-saving) ──────────────────────────────────────────
+
+function TelemetrySection({ settings, onSaved }: { settings: Settings; onSaved: (s: Settings) => void }) {
+  const t = settings.telemetry;
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  async function toggle(enabled: boolean) {
+    setSaving(true);
+    setError('');
+    try {
+      const updated = await updateSettings({ telemetry: { enabled } } as Partial<Settings>);
+      onSaved(updated);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={{ marginBottom: 28 }}>
+      <h3 style={{ fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-muted)', marginBottom: 12, display: 'flex', alignItems: 'center', gap: 6 }}>
+        <BarChart2 size={13} /> Anonymous Metrics
+      </h3>
+
+      <div style={{ padding: '14px 16px', border: '1px solid var(--border)', borderRadius: 8, background: 'var(--bg-elevated)' }}>
+        <p style={{ fontSize: '0.83rem', color: 'var(--text-primary)', margin: '0 0 4px' }}>
+          <strong>Routerly never sends data automatically.</strong>{' '}
+          {t === undefined
+            ? 'You have not made a choice yet.'
+            : t.enabled
+              ? 'Anonymous install metrics are enabled.'
+              : 'Anonymous install metrics are disabled.'}
+        </p>
+        <p style={{ fontSize: '0.75rem', color: 'var(--text-muted)', margin: '0 0 12px' }}>
+          When enabled, Routerly sends only: event type (install / upgrade / uninstall), version, platform, and a random ID.
+          No personal data, no usage data, no IP stored.{' '}
+          <a href="https://doc.routerly.ai/reference/telemetry" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)', textDecoration: 'none' }}>
+            What is sent?
+          </a>
+        </p>
+
+        {t?.enabled && t.installId && (
+          <p style={{ fontSize: '0.72rem', color: 'var(--text-muted)', margin: '0 0 12px', fontFamily: 'monospace' }}>
+            Install ID: {t.installId}
+          </p>
+        )}
+
+        {error && <p style={{ fontSize: '0.78rem', color: 'var(--error, #e53e3e)', margin: '0 0 10px' }}>{error}</p>}
+
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <button
+            type="button"
+            className={`btn btn-sm ${t?.enabled ? 'btn-primary' : 'btn-secondary'}`}
+            disabled={saving || t?.enabled === true}
+            onClick={() => toggle(true)}
+            style={{ fontSize: '0.8rem' }}
+          >
+            {saving && !t?.enabled ? <><div className="spinner" style={{ width: 11, height: 11 }} /> Saving…</> : 'Enable'}
+          </button>
+          <button
+            type="button"
+            className={`btn btn-sm ${t?.enabled === false ? 'btn-primary' : 'btn-secondary'}`}
+            disabled={saving || t?.enabled === false}
+            onClick={() => toggle(false)}
+            style={{ fontSize: '0.8rem' }}
+          >
+            {saving && t?.enabled ? <><div className="spinner" style={{ width: 11, height: 11 }} /> Saving…</> : 'Disable'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 // ── General tab ───────────────────────────────────────────────────────────────
 
@@ -131,6 +207,11 @@ export function SettingsGeneralTab() {
         </div>
 
       </div>
+
+      <TelemetrySection
+        settings={settings!}
+        onSaved={updated => setSettings(updated)}
+      />
 
       {error && <div className="form-error" style={{ marginBottom: 16 }}>{error}</div>}
       {saved && (

--- a/packages/service/src/routes/api.ts
+++ b/packages/service/src/routes/api.ts
@@ -1,10 +1,11 @@
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import bcrypt from 'bcrypt';
 import { v4 as uuidv4 } from 'uuid';
 import { randomBytes } from 'node:crypto';
+import { pingTelemetry } from '../telemetry.js';
 import { readConfig, writeConfig } from '../config/loader.js';
 import { CONFIG_PATHS } from '../config/paths.js';
 import { createSessionToken, verifyToken, generateRawToken } from '../plugins/jwt.js';
@@ -897,6 +898,18 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
     for (const key of allowed) {
       if ((req.body as Partial<Settings>)[key] !== undefined) {
         (updated as any)[key] = (req.body as Partial<Settings>)[key];
+      }
+    }
+    // Telemetry is handled separately: server controls installId generation
+    const telemetryPatch = (req.body as Partial<Settings>).telemetry;
+    if (telemetryPatch !== undefined) {
+      const wasEnabled = current.telemetry?.enabled === true;
+      if (telemetryPatch.enabled) {
+        const installId = current.telemetry?.installId || randomUUID();
+        updated.telemetry = { enabled: true, installId };
+        if (!wasEnabled) pingTelemetry(installId, 'install');
+      } else {
+        updated.telemetry = { enabled: false, installId: current.telemetry?.installId ?? '' };
       }
     }
     await writeConfig('settings', updated);

--- a/packages/service/src/telemetry.ts
+++ b/packages/service/src/telemetry.ts
@@ -3,26 +3,33 @@ import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
 
 const _dir = dirname(fileURLToPath(import.meta.url));
-const { version: pkgVersion } = JSON.parse(
-  readFileSync(join(_dir, '../package.json'), 'utf-8'),
-) as { version: string };
+
+// Never let a missing/malformed package.json crash the service at startup.
+let pkgVersion = 'unknown';
+try {
+  const raw = JSON.parse(readFileSync(join(_dir, '../package.json'), 'utf-8')) as { version?: string };
+  if (raw.version) pkgVersion = raw.version;
+} catch { /* fallback to 'unknown' */ }
 
 export const TELEMETRY_ENDPOINT = 'https://telemetry.routerly.ai/ping';
 
 export type TelemetryEvent = 'install' | 'upgrade' | 'uninstall';
 
 export function pingTelemetry(installId: string, event: TelemetryEvent): void {
-  const payload = {
-    event,
-    version: pkgVersion,
-    platform: process.platform,
-    installId,
-  };
+  // Outer try/catch: any synchronous error (bad env, missing globals) is silently swallowed.
+  try {
+    const payload = {
+      event,
+      version: pkgVersion,
+      platform: process.platform,
+      installId,
+    };
 
-  fetch(TELEMETRY_ENDPOINT, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(3000),
-  }).catch(() => { /* fire-and-forget */ });
+    fetch(TELEMETRY_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(3000),
+    }).catch(() => { /* fire-and-forget: network errors, timeouts, server down */ });
+  } catch { /* never propagate to the caller */ }
 }

--- a/packages/service/src/telemetry.ts
+++ b/packages/service/src/telemetry.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+const _dir = dirname(fileURLToPath(import.meta.url));
+const { version: pkgVersion } = JSON.parse(
+  readFileSync(join(_dir, '../package.json'), 'utf-8'),
+) as { version: string };
+
+export const TELEMETRY_ENDPOINT = 'https://telemetry.routerly.ai/ping';
+
+export type TelemetryEvent = 'install' | 'upgrade' | 'uninstall';
+
+export function pingTelemetry(installId: string, event: TelemetryEvent): void {
+  const payload = {
+    event,
+    version: pkgVersion,
+    platform: process.platform,
+    installId,
+  };
+
+  fetch(TELEMETRY_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(3000),
+  }).catch(() => { /* fire-and-forget */ });
+}

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -304,6 +304,13 @@ export type Permission =
   | 'user:write'
   | 'report:read';
 
+export interface TelemetryConfig {
+  /** Whether the user has opted in to anonymous install metrics */
+  enabled: boolean;
+  /** Random UUID generated once at opt-in time, never changes */
+  installId: string;
+}
+
 export interface Settings {
   port: number;
   host: string;
@@ -323,6 +330,8 @@ export interface Settings {
   notifications?: NotificationsConfig;
   /** Distribution channel for updates: 'latest' | 'stable' | 'develop' | vX.Y.Z tag */
   channel?: string;
+  /** Anonymous install metrics opt-in. Absent means the user has not been asked yet. */
+  telemetry?: TelemetryConfig;
 }
 
 // ─── Update info ─────────────────────────────────────────────────────────────

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -424,7 +424,7 @@ if (isExistingInstall && !YES) {
     }
 
     if (!FLAG_NO_TELEMETRY && existingSettings.telemetry?.enabled && existingSettings.telemetry?.installId) {
-      await pingTelemetry('uninstall', existingSettings.telemetry.installId);
+      try { await pingTelemetry('uninstall', existingSettings.telemetry.installId); } catch { /* never block uninstall */ }
     }
     console.log('\n' + c.green(c.bold('  Routerly uninstalled successfully.')) + '\n');
     rl.close(); process.exit(0);
@@ -991,7 +991,7 @@ if (installService && installMode === 'fresh') {
 
 // Send upgrade ping if the user had previously opted in
 if (isUpdate && !FLAG_NO_TELEMETRY && existingSettings.telemetry?.enabled && existingSettings.telemetry?.installId) {
-  await pingTelemetry('upgrade', existingSettings.telemetry.installId);
+  try { await pingTelemetry('upgrade', existingSettings.telemetry.installId); } catch { /* never block upgrade */ }
 }
 
 // On fresh installs, ask for anonymous metrics consent (skip in CI or --no-telemetry)

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -58,6 +58,7 @@ const FLAG_HOST      = getArg('host')        ?? process.env.ROUTERLY_HOST       
 const FLAG_URL       = getArg('public-url')  ?? process.env.ROUTERLY_PUBLIC_URL  ?? '';
 const INSTALL_VERSION = getArg('version') ?? ''; // set by install.sh/ps1 via --version=vX.Y.Z
 const INSTALL_CHANNEL = getArg('channel') ?? 'latest'; // set by install.sh/ps1 via --channel=
+const FLAG_NO_TELEMETRY = hasFlag('no-telemetry') || process.env.CI === '1' || process.env.CI === 'true';
 
 // From env vars (--yes mode)
 const ENV_INSTALL_SVC  = process.env.ROUTERLY_INSTALL_SERVICE;
@@ -422,6 +423,9 @@ if (isExistingInstall && !YES) {
       info(`User data kept at ${c.dim(cliHome)}`);
     }
 
+    if (!FLAG_NO_TELEMETRY && existingSettings.telemetry?.enabled && existingSettings.telemetry?.installId) {
+      await pingTelemetry('uninstall', existingSettings.telemetry.installId);
+    }
     console.log('\n' + c.green(c.bold('  Routerly uninstalled successfully.')) + '\n');
     rl.close(); process.exit(0);
   }
@@ -984,6 +988,34 @@ if (installService && installMode === 'fresh') {
 // ════════════════════════════════════════════════════════════════════════════
 // Done
 // ════════════════════════════════════════════════════════════════════════════
+
+// Send upgrade ping if the user had previously opted in
+if (isUpdate && !FLAG_NO_TELEMETRY && existingSettings.telemetry?.enabled && existingSettings.telemetry?.installId) {
+  await pingTelemetry('upgrade', existingSettings.telemetry.installId);
+}
+
+// On fresh installs, ask for anonymous metrics consent (skip in CI or --no-telemetry)
+if (!isUpdate && !FLAG_NO_TELEMETRY && installService) {
+  console.log('\n' + '─'.repeat(60));
+  console.log(c.dim('\n  Help improve Routerly? (completely optional)\n'));
+  console.log('  Sends only: event type, version, platform, and a random ID.');
+  console.log('  No personal data. No IP stored. Opt out anytime:');
+  console.log(c.dim('    routerly telemetry off\n'));
+  const wantsMetrics = await confirm('  Send anonymous install metrics?', false);
+  if (wantsMetrics) {
+    const installId = randomBytes(16).toString('hex');
+    try {
+      if (fs.existsSync(settingsPath)) {
+        const current = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        current.telemetry = { enabled: true, installId };
+        await writeFileP(settingsPath, JSON.stringify(current, null, 2), needsSudo);
+      }
+      await pingTelemetry('install', installId);
+      success('Anonymous metrics enabled. Thank you!');
+    } catch { /* ignore, non-critical */ }
+  }
+}
+
 console.log('\n' + '─'.repeat(60));
 console.log(c.green(c.bold('\n  Routerly installed successfully!\n')));
 
@@ -1220,6 +1252,21 @@ async function setupWindowsService({ serviceEntry, nodeExe, routerlyHome, port }
     console.log(`  set ROUTERLY_HOME=${routerlyHome}`);
     console.log(`  node "${serviceEntry}"`);
   }
+}
+
+/** Fire-and-forget telemetry ping. Never throws. */
+async function pingTelemetry(event, installId) {
+  const version = INSTALL_VERSION || 'unknown';
+  try {
+    await Promise.race([
+      fetch('https://telemetry.routerly.ai/ping', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ event, installId, version, platform: PLATFORM }),
+      }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 3000)),
+    ]);
+  } catch { /* ignore */ }
 }
 
 /** Create admin user using the public setup endpoint (no auth required). */

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -147,6 +147,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'reference/config-files',
         'reference/environment-variables',
+        'reference/telemetry',
         'reference/troubleshooting',
       ],
     },


### PR DESCRIPTION
## Summary

- Adds strictly opt-in anonymous install metrics (install / upgrade / uninstall events)
- **Routerly never sends data without explicit user consent** — no defaults, no background pings
- Users are asked once during installation (default: no); Docker/manual installs see a one-time dashboard banner
- Full transparency: `docs/reference/telemetry.md` documents exactly what is sent, when, and why

## What ships

| Area | Change |
|------|--------|
| `packages/shared` | New `TelemetryConfig` type; `telemetry?` field on `Settings` |
| `packages/service` | `pingTelemetry()` utility (fire-and-forget, 3s timeout); `PUT /api/settings` handles consent — server generates `installId`, sends `install` ping only on first enable |
| `packages/cli` | New `routerly telemetry status\|on\|off` command |
| `packages/dashboard` | Admin-only banner (shown once for Docker/manual installs) + **Settings > General** section to change preference at any time |
| `scripts/install.mjs` | Explicit consent prompt post-install (default no), upgrade ping, uninstall ping, `--no-telemetry` flag, CI auto-skip |
| `docs/reference/telemetry.md` | Full transparency page linked from every consent touch-point |
| `website/sidebars.ts` | Telemetry page added to Reference section |

## Test plan

- [ ] Fresh install via script: consent prompt appears, default is "no", "yes" writes `settings.json` and fires ping
- [ ] `--no-telemetry` flag: no prompt, no ping
- [ ] `CI=true`: no prompt, no ping
- [ ] Upgrade with prior consent: upgrade ping fired
- [ ] Uninstall with prior consent: uninstall ping fired before removal
- [ ] `routerly telemetry status/on/off` CLI commands
- [ ] Dashboard banner appears for admin on first load when `settings.telemetry` is undefined; disappears after choice
- [ ] Settings > General shows current state, Enable/Disable save immediately
- [ ] Typecheck + tests pass: `npm run typecheck`, `npm test --workspace=packages/service`, `npm test --workspace=packages/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)