### PR TITLE
feat(dashboard): help & support page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## What happened?
+
+<!-- Describe the problem in plain words. What did you see? -->
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behaviour
+
+<!-- What did you expect to happen? -->
+
+## Actual behaviour
+
+<!-- What actually happened? -->
+
+## Environment
+
+- **Routerly version**: <!-- run `routerly --version` or check Settings → About -->
+- **Installation type**: <!-- Docker / npm / binary -->
+- **OS**: <!-- e.g. macOS 14, Ubuntu 22.04, Windows 11 -->
+- **Node version** (if not Docker): <!-- run `node -v` -->
+
+## Logs or error output
+
+<!-- If applicable, paste relevant logs here. Wrap them in ``` blocks. -->
+
+```
+paste logs here
+```
+
+## Additional context
+
+<!-- Anything else that might help us understand the issue (screenshots, config snippets, etc.) -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature Request
+about: Suggest an idea or improvement for Routerly
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## What problem does this solve?
+
+<!-- Describe the situation or limitation that motivates this request.
+     e.g. "I often need to... but currently there's no way to..." -->
+
+## Proposed solution
+
+<!-- Describe what you'd like to happen. Be as specific as you can. -->
+
+## Alternatives you've considered
+
+<!-- Have you tried any workarounds? Are there other ways to solve this? -->
+
+## Who would benefit from this?
+
+<!-- Is this specific to your use case, or do you think it's broadly useful?
+     e.g. "anyone routing to multiple providers", "teams with per-project budgets", etc. -->
+
+## Additional context
+
+<!-- Screenshots, mockups, links to similar features in other tools, etc. -->

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -87,7 +87,6 @@ function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => 
     { to: '/dashboard/projects', icon: <FolderOpen size={17} />, label: 'Projects' },
     { to: '/dashboard/usage', icon: <BarChart2 size={17} />, label: 'Usage' },
     { to: '/dashboard/test', icon: <FlaskConical size={17} />, label: 'Test' },
-    { to: '/dashboard/help', icon: <HelpCircle size={17} />, label: 'Help' },
   ];
 
   return (
@@ -139,6 +138,14 @@ function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => 
         >
           <SettingsIcon size={15} />
           <span className="nav-label">Settings</span>
+        </NavLink>
+        <NavLink
+          to="/dashboard/help"
+          title={collapsed ? 'Help' : undefined}
+          className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}
+        >
+          <HelpCircle size={15} />
+          <span className="nav-label">Help</span>
         </NavLink>
         <button className="nav-item sign-out" title="Sign Out" onClick={handleLogout}>
           <LogOut size={15} />

--- a/packages/dashboard/src/pages/HelpPage.tsx
+++ b/packages/dashboard/src/pages/HelpPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Bug, ExternalLink, Mail, ChevronDown, ChevronRight, MessageSquarePlus } from 'lucide-react';
+import { BookOpen, Bug, ExternalLink, Mail, ChevronDown, ChevronRight, MessageSquarePlus } from 'lucide-react';
 
 const FAQ_ITEMS = [
   {
@@ -111,6 +111,35 @@ export function HelpPage() {
       </div>
 
       <div className="page-body" style={{ display: 'flex', flexDirection: 'column', gap: 20, maxWidth: 640 }}>
+
+        {/* ── Documentation ─────────────────────────────────────────────────── */}
+        <Card>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+            <div style={{
+              width: 34, height: 34, borderRadius: 8,
+              background: 'rgba(139,92,246,0.12)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+            }}>
+              <BookOpen size={17} color="#8b5cf6" />
+            </div>
+            <div>
+              <div style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--text-primary)' }}>Documentation</div>
+              <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', marginTop: 1 }}>Guides, API reference, and configuration docs</div>
+            </div>
+          </div>
+          <p style={{ fontSize: '0.84rem', color: 'var(--text-secondary)', lineHeight: 1.6, margin: '0 0 14px' }}>
+            The official docs cover everything from getting started to advanced routing policies, provider setup, budgets, and the full API reference.
+          </p>
+          <a
+            href="https://doc.routerly.ai/next/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn btn-secondary btn-sm"
+            style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 6 }}
+          >
+            <ExternalLink size={13} /> Open documentation
+          </a>
+        </Card>
 
         {/* ── GitHub Issues ──────────────────────────────────────────────────── */}
         <Card>


### PR DESCRIPTION
## Summary

- New `/dashboard/help` page with four sections: documentation link, GitHub issue templates (bug/feature), support email, and accordion FAQ
- Help link in the sidebar footer, above Sign Out
- GitHub issue templates added (`.github/ISSUE_TEMPLATE/`) so the forms are pre-filled when opened from the Help page

## Test plan

- [ ] Visit `/dashboard/help` — four cards visible (docs, GitHub issues, email, FAQ)
- [ ] Help link appears in the sidebar footer above Sign Out
- [ ] Collapsed sidebar shows the `HelpCircle` icon with tooltip
- [ ] "Report a bug" / "Request a feature" buttons open GitHub with the correct pre-filled template
- [ ] "Open documentation" opens `doc.routerly.ai/next/`
- [ ] FAQ accordion opens/closes correctly
- [ ] `support@routerly.ai` mailto link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)