### PR TITLE
chore: add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## What happened?
+
+<!-- Describe the problem in plain words. What did you see? -->
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behaviour
+
+<!-- What did you expect to happen? -->
+
+## Actual behaviour
+
+<!-- What actually happened? -->
+
+## Environment
+
+- **Routerly version**: <!-- run `routerly --version` or check Settings → About -->
+- **Installation type**: <!-- Docker / npm / binary -->
+- **OS**: <!-- e.g. macOS 14, Ubuntu 22.04, Windows 11 -->
+- **Node version** (if not Docker): <!-- run `node -v` -->
+
+## Logs or error output
+
+<!-- If applicable, paste relevant logs here. Wrap them in ``` blocks. -->
+
+```
+paste logs here
+```
+
+## Additional context
+
+<!-- Anything else that might help us understand the issue (screenshots, config snippets, etc.) -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature Request
+about: Suggest an idea or improvement for Routerly
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## What problem does this solve?
+
+<!-- Describe the situation or limitation that motivates this request.
+     e.g. "I often need to... but currently there's no way to..." -->
+
+## Proposed solution
+
+<!-- Describe what you'd like to happen. Be as specific as you can. -->
+
+## Alternatives you've considered
+
+<!-- Have you tried any workarounds? Are there other ways to solve this? -->
+
+## Who would benefit from this?
+
+<!-- Is this specific to your use case, or do you think it's broadly useful?
+     e.g. "anyone routing to multiple providers", "teams with per-project budgets", etc. -->
+
+## Additional context
+
+<!-- Screenshots, mockups, links to similar features in other tools, etc. -->


### PR DESCRIPTION
## Summary

Adds `.github/ISSUE_TEMPLATE/` with two templates:
- `bug_report.md` — pre-fills title, labels, and structured sections (steps to reproduce, expected/actual behaviour, environment, logs)
- `feature_request.md` — pre-fills title, labels, and structured sections (problem, proposed solution, alternatives, audience)

These are needed **on main** so the links in the dashboard Help page work immediately:
- `issues/new?labels=bug&template=bug_report.md`
- `issues/new?labels=enhancement&template=feature_request.md`

No code changes — templates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)