### PR TITLE
fix(release): fix e2e tests, docker json imports, add cost calculator tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ dist/
 build/
 out/
 *.tsbuildinfo
+**/*.tsbuildinfo
 
 # Git
 .git/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,94 @@
+# Changelog
+
+All notable changes to Routerly are documented in this file.
+
+---
+
+## [0.2.0] — 2026-06-10
+
+### New features
+
+**Semantic response cache**
+Responses are now cached by semantic similarity of the prompt. Repeated or semantically equivalent requests are served from cache, reducing cost and latency. Cache hits are tracked in usage logs and visible in the dashboard.
+
+**Semantic intent routing**
+A new routing policy matches incoming requests to models based on declared semantic intent. Projects can save routing feedback from the dashboard to improve intent matching over time.
+
+**Anthropic Messages API**
+Full support for the Anthropic `/v1/messages` endpoint with multi-provider fallback. Claude Desktop and other Anthropic-native clients can now use Routerly as a drop-in proxy.
+
+**Conversation-aware routing memory**
+The routing engine now maintains a short-term conversation memory store. Subsequent turns in the same conversation are routed to the same model, improving coherence in multi-turn sessions.
+
+**Per-request cost breakdown**
+Every request now records a detailed cost breakdown (input tokens, output tokens, cache read/write tokens) in usage logs. The dashboard displays this breakdown in the usage detail view.
+
+**New model providers**
+Added built-in support for: DeepSeek, Groq, Together AI, and Perplexity. Pricing and context-window data are included in the model catalog.
+
+**New model catalog entries**
+Added `claude-fable-5`, `claude-opus-4-8`, `claude-opus-4-7` with correct pricing and context-window data.
+
+**Decoupled model IDs**
+The Routerly model ID is now independent of the upstream provider API model name. This enables cleaner aliases and model renaming without breaking existing configurations.
+
+**Built-in update checker**
+Routerly now polls GitHub Releases every 24 hours and compares the running version against the configured channel (`latest`, `current`, `develop`, or a pinned tag). The result is cached in memory and surfaced via the dashboard and CLI.
+
+**Dynamic update channels**
+Available update channels and release tags are loaded directly from GitHub Releases at runtime. The channel selector in the dashboard always shows the base channels plus any published release tags.
+
+**CLI update commands**
+Three new subcommands under `routerly update`:
+- `routerly update check` — show whether a newer version is available on the active channel
+- `routerly update channel [name]` — get or set the update channel
+- `routerly update run` — download and install the latest version (non-Docker only)
+
+**Software Update section in the dashboard**
+The Settings → About tab now shows the current channel, the latest available version, the last-checked timestamp, and a one-click update button. The channel selector is populated dynamically from GitHub Releases and always includes the base channels.
+
+**Opt-in anonymous telemetry**
+Install metrics (event type, version, platform, anonymous install ID) can be enabled or disabled from the dashboard Settings or via `routerly telemetry enable/disable`. Disabled by default.
+
+**Help & Support page**
+New Help page in the dashboard with links to documentation, GitHub Issues, and email support, plus an FAQ section for common questions.
+
+**New management API endpoints**
+- `GET /api/system/info` — system info (version, channel, Docker flag, update status) — public, no auth required
+- `GET /api/system/update-check` — trigger an immediate update check (admin auth required)
+- `POST /api/system/update` — run the in-app updater (admin JWT required; disabled in Docker)
+- `GET /api/system/releases` — list available channels and version tags from GitHub Releases
+
+**Improved dashboard UX**
+- Policy editor: add/remove policies with a searchable select
+- Usage page: time-based filtering and pagination
+- Models are sorted alphabetically in all selectors
+
+### Bug fixes and maintenance
+
+- Fixed `GET /api/system/info` being incorrectly protected by JWT middleware — it is now public
+- Fixed Qwen3 thinking-only response handling in the Ollama adapter
+- Fixed `reasoning_effort` being forwarded to non-o-series OpenAI models
+- Fixed Fastify v5 `decorateRequest` compatibility
+- Fixed missing `draft` field in GitHub Release interface
+- Fixed update channel selector always showing base channels, removed version downgrade option
+- Upgraded Fastify v5, Vite v6, Vitest v4, Commander v14, Zod v4, lucide-react
+- Fixed Vitest 4.x compatibility (`loadEnv` import moved from `vitest/config` to `vite`)
+- Hardened supply-chain security (pinned action hashes, `npm audit --audit-level=high`)
+- Added unit tests for cost calculator (`calculateCost`)
+
+### Breaking changes
+
+None. The OpenAI and Anthropic wire formats are unchanged.
+
+---
+
+## [0.1.5] — 2026-03-27
+
+See [GitHub Release](https://github.com/Inebrio/Routerly/releases/tag/v0.1.5).
+
+---
+
+## [0.1.4] and earlier
+
+See the [GitHub Releases page](https://github.com/Inebrio/Routerly/releases).

--- a/ai/learnings/ERRORS.md
+++ b/ai/learnings/ERRORS.md
@@ -3,3 +3,66 @@
 See `ai/skills/autoimprove/SKILL.md` for the log format.
 
 <!-- Append new entries below this line -->
+
+## [ERR-20260610-001] Docker build / packages/shared/dist not found
+
+**Logged**: 2026-06-10T00:00:00Z
+**Priority**: high
+**Status**: resolved
+
+### Summary
+`docker build` fails with `"/app/packages/shared/dist": not found` in the production stage, despite the builder stage running `npm run build --workspace=packages/shared` successfully.
+
+### Error
+```
+ERROR: failed to build: failed to solve: failed to compute cache key:
+  "/app/packages/shared/dist": not found
+```
+
+### Context
+- The `.dockerignore` excluded `**/dist/` (correct) but also excluded only `*.tsbuildinfo` at root level, not `**/*.tsbuildinfo`
+- TypeScript `composite: true` uses incremental builds. When `tsconfig.tsbuildinfo` from the host is copied into the Docker context, `tsc` sees the build as up-to-date and skips generating `dist/`
+- No error is reported by `tsc` — silent no-op
+
+### Suggested Fix
+Add `**/*.tsbuildinfo` to `.dockerignore`. Done in this session.
+
+### Metadata
+- Reproducible: yes
+- Related Files: .dockerignore, packages/shared/tsconfig.json
+- Resolution: 2026-06-10 — added `**/*.tsbuildinfo` to `.dockerignore`
+
+---
+
+## [ERR-20260610-002] Node 22+/25+ requires import attributes for JSON modules
+
+**Logged**: 2026-06-10T00:00:00Z
+**Priority**: high
+**Status**: resolved
+
+### Summary
+Service fails to start in Docker (node:25-alpine) with `ERR_IMPORT_ATTRIBUTE_MISSING` for JSON imports in `@routerly/shared`.
+
+### Error
+```
+TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module "file:///app/packages/shared/dist/conf/providers.json"
+needs an import attribute of "type: json"
+```
+
+### Context
+- `packages/shared/src/index.ts` and `browser.ts` imported JSON via bare `import x from './conf/providers.json'`
+- Node.js 22+ / 25+ requires `with { type: 'json' }` attribute
+- TypeScript `module: "Node16"` does not support import attributes syntax — must use `"NodeNext"`
+- After upgrading to `NodeNext`, also need to delete `.tsbuildinfo` files for clean compilation
+
+### Suggested Fix
+1. Change `tsconfig.base.json`: `"module": "NodeNext"`, `"moduleResolution": "NodeNext"`
+2. Update JSON imports: `import x from './foo.json' with { type: 'json' }`
+3. Delete `**/*.tsbuildinfo` before first build after tsconfig change
+
+### Metadata
+- Reproducible: yes
+- Related Files: tsconfig.base.json, packages/shared/src/index.ts, packages/shared/src/browser.ts
+- Resolution: 2026-06-10 — both fixes applied
+
+---

--- a/ai/learnings/LEARNINGS.md
+++ b/ai/learnings/LEARNINGS.md
@@ -3,3 +3,74 @@
 See `ai/skills/autoimprove/SKILL.md` for the log format.
 
 <!-- Append new entries below this line -->
+
+## [LRN-20260610-001] knowledge_gap
+
+**Logged**: 2026-06-10T00:00:00Z
+**Priority**: high
+**Status**: promoted
+**Promoted to**: ai/policies/coding-style.md (JSON imports section)
+**Area**: service
+
+### Summary
+`vitest/config` does not export `loadEnv` in vitest 4.x — must import from `vite` instead.
+
+### Details
+Root `vitest.config.ts` used `import { defineConfig, loadEnv } from 'vitest/config'`. Starting with vitest 4.x, `loadEnv` was removed from vitest's re-exports. Import it from `vite` directly.
+
+### Suggested Action
+Always import `loadEnv` from `'vite'`, not `'vitest/config'`.
+
+### Metadata
+- Source: error
+- Related Files: vitest.config.ts
+- Tags: vitest, imports, testing
+
+---
+
+## [LRN-20260610-002] knowledge_gap
+
+**Logged**: 2026-06-10T00:00:00Z
+**Priority**: high
+**Status**: promoted
+**Promoted to**: ai/policies/coding-style.md, ai/memory/constraints.md
+**Area**: service, shared
+
+### Summary
+`tsconfig.base.json` must use `module: NodeNext` (not `Node16`) to support JSON import attributes (`with { type: 'json' }`), required by Node 22+.
+
+### Details
+`module: "Node16"` predates import attribute support in TypeScript. Upgrading to `"NodeNext"` is backward-compatible for this project and unlocks the `with { type: 'json' }` syntax. After the change, delete all `*.tsbuildinfo` files to force a clean build.
+
+### Suggested Action
+Use `"module": "NodeNext"` and `"moduleResolution": "NodeNext"` in `tsconfig.base.json`.
+
+### Metadata
+- Source: error
+- Related Files: tsconfig.base.json, packages/shared/src/index.ts
+- Tags: typescript, json-imports, node22, node25, docker
+
+---
+
+## [LRN-20260610-003] best_practice
+
+**Logged**: 2026-06-10T00:00:00Z
+**Priority**: medium
+**Status**: pending
+**Area**: service
+
+### Summary
+`GET /api/system/info` should be explicitly whitelisted in the JWT preHandler to be public; absence of an `if (!req.dashUser)` check in the route handler is not sufficient.
+
+### Details
+The JWT preHandler (line 178 in api.ts) blocks ALL `/api/*` routes by default. A route that omits the `req.dashUser` check still gets blocked by the middleware. If the intent is a public endpoint, it must be added to the whitelist explicitly.
+
+### Suggested Action
+When adding a new public `/api/*` endpoint, always add it to the preHandler whitelist alongside `/api/auth/login`, `/api/auth/refresh`, and `/api/setup/*`.
+
+### Metadata
+- Source: error
+- Related Files: packages/service/src/routes/api.ts:178-183
+- Tags: auth, middleware, api
+
+---

--- a/ai/memory/constraints.md
+++ b/ai/memory/constraints.md
@@ -19,6 +19,8 @@ These constraints are not up for debate. Violating them requires an explicit tea
 - **NEVER** use `require()` — the project is ESM-only
 - **NEVER** use `import type` for runtime values (use a regular `import`)
 - **ALWAYS** extend `tsconfig.base.json` from the root in every new package
+- **ALWAYS** use `with { type: 'json' }` for JSON imports — bare JSON imports fail on Node 22+
+- **NEVER** add a new public `/api/*` route without explicitly whitelisting it in the JWT preHandler (api.ts:178)
 
 ## Documentation
 

--- a/ai/policies/coding-style.md
+++ b/ai/policies/coding-style.md
@@ -20,12 +20,19 @@
 
 - **Strict mode**: `"strict": true` in `tsconfig.base.json` — no exceptions
 - **No `any`**: use `unknown` and narrow, or `never` for exhaustive checks
-- **Import extensions**: always `.js` (required by Node16 resolution)
+- **Import extensions**: always `.js` (required by NodeNext resolution)
   ```ts
   // ✅ correct
   import { readConfig } from './config/loader.js'
   // ❌ wrong
   import { readConfig } from './config/loader'
+  ```
+- **JSON imports**: always use `with { type: 'json' }` attribute (required by Node 22+)
+  ```ts
+  // ✅ correct
+  import data from './conf/data.json' with { type: 'json' }
+  // ❌ wrong — ERR_IMPORT_ATTRIBUTE_MISSING on Node 22+
+  import data from './conf/data.json'
   ```
 - **Node builtins**: always `node:` prefix
   ```ts

--- a/packages/service/src/cost/calculator.test.ts
+++ b/packages/service/src/cost/calculator.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { calculateCost } from './calculator.js'
+import type { ModelConfig } from '@routerly/shared'
+
+function model(overrides: Partial<ModelConfig['cost']> = {}): ModelConfig {
+  return {
+    id: 'test-model',
+    name: 'Test',
+    provider: 'openai',
+    endpoint: 'http://localhost',
+    cost: {
+      inputPerMillion: 1.0,
+      outputPerMillion: 2.0,
+      ...overrides,
+    },
+  } as ModelConfig
+}
+
+describe('calculateCost', () => {
+  it('basic input + output cost', () => {
+    const cost = calculateCost(1_000_000, 1_000_000, model())
+    expect(cost).toBeCloseTo(3.0, 9)
+  })
+
+  it('zero tokens → zero cost', () => {
+    expect(calculateCost(0, 0, model())).toBe(0)
+  })
+
+  it('cached input uses cachePerMillion when set', () => {
+    const m = model({ cachePerMillion: 0.1 })
+    // 1M cached tokens at 0.1/M + 1M output at 2/M = 2.1
+    const cost = calculateCost(1_000_000, 1_000_000, m, 1_000_000)
+    expect(cost).toBeCloseTo(2.1, 9)
+  })
+
+  it('cached input falls back to inputPerMillion when cachePerMillion absent', () => {
+    // 1M cached → inputPerMillion(1.0) + 1M output → 2.0 = 3.0
+    const cost = calculateCost(1_000_000, 1_000_000, model(), 1_000_000)
+    expect(cost).toBeCloseTo(3.0, 9)
+  })
+
+  it('cache write uses cacheWritePerMillion when set', () => {
+    const m = model({ cacheWritePerMillion: 0.5 })
+    // 1M write at 0.5 + 1M output at 2.0 = 2.5
+    const cost = calculateCost(1_000_000, 1_000_000, m, 0, 1_000_000)
+    expect(cost).toBeCloseTo(2.5, 9)
+  })
+
+  it('cache write falls back to inputPerMillion when cacheWritePerMillion absent', () => {
+    // 1M write at 1.0 + 1M output at 2.0 = 3.0
+    const cost = calculateCost(1_000_000, 1_000_000, model(), 0, 1_000_000)
+    expect(cost).toBeCloseTo(3.0, 9)
+  })
+
+  it('cached + write tokens are subtracted from plain input', () => {
+    // 2M inputTokens, 500k cached, 500k write → 1M plain at 1.0 = 1.0
+    // + 500k cached at 1.0 = 0.5
+    // + 500k write at 1.0  = 0.5
+    // + 0 output            = 0
+    const cost = calculateCost(2_000_000, 0, model(), 500_000, 500_000)
+    expect(cost).toBeCloseTo(2.0, 9)
+  })
+
+  it('small token count rounds correctly', () => {
+    // 1 input token at $1/M + 1 output at $2/M = 0.000003
+    const cost = calculateCost(1, 1, model())
+    expect(cost).toBeCloseTo(0.000003, 9)
+  })
+})

--- a/packages/service/src/routes/api.ts
+++ b/packages/service/src/routes/api.ts
@@ -180,6 +180,7 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
     if (req.url === '/api/auth/login') return;
     if (req.url === '/api/auth/refresh') return;
     if (req.url.startsWith('/api/setup/')) return;
+    if (req.url === '/api/system/info') return;
 
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) {

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -4,7 +4,7 @@
  */
 
 // Static configuration data (JSON, safe in any environment)
-import providersConf from './conf/providers.json';
+import providersConf from './conf/providers.json' with { type: 'json' };
 export { providersConf };
 
 // Re-export all types (erased at compile time, no runtime cost)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -81,5 +81,5 @@ export type {
 export type { RoutingCandidate, RoutingResponse } from './types/routing.js';
 
 // Static configuration data
-import providersConf from './conf/providers.json';
+import providersConf from './conf/providers.json' with { type: 'json' };
 export { providersConf };

--- a/scripts/release-0.2.0.sh
+++ b/scripts/release-0.2.0.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Routerly 0.2.0 release script — run off-hours (before 09:00 or after 18:00, no weekends)
+# Prerequisites: gh auth status && docker login (inebrio account)
+set -euo pipefail
+
+REPO="Inebrio/Routerly"
+DOCKER_IMAGE="inebrio/routerly"
+VERSION="0.2.0"
+TAG="v${VERSION}"
+
+echo "=== Routerly ${TAG} Release Script ==="
+
+# Step 1: Commit
+echo "→ Step 1: Commit"
+git commit -m "fix(release): fix E2E tests, Docker JSON imports, add cost calculator tests
+
+- vitest.config.ts: move loadEnv from vitest/config to vite (vitest 4.x)
+- api.ts: add /api/system/info to JWT middleware whitelist (public endpoint)
+- e2e.test.ts: update POST /api/system/update assertions 403 -> 401
+- shared JSON imports: add with { type: 'json' } for Node 22+/25+ compat
+- tsconfig.base.json: Node16 -> NodeNext (supports import attributes)
+- .dockerignore: add **/*.tsbuildinfo (prevent stale incremental cache in Docker)
+- CHANGELOG.md: add full 0.2.0 release notes
+- cost/calculator.test.ts: 8 unit tests for calculateCost
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+
+# Step 2: Push develop
+echo "→ Step 2: Push develop"
+git push origin develop
+
+# Step 3: PR develop -> main
+echo "→ Step 3: PR develop -> main"
+PR_BODY_FILE="$(mktemp)"
+cat > "${PR_BODY_FILE}" << 'PRBODY'
+## Routerly 0.2.0 — Release candidate
+
+### New features
+- Semantic response cache (embeddings-based)
+- Semantic intent routing policy
+- Anthropic Messages API with multi-provider fallback (Claude Desktop compatible)
+- Conversation-aware routing memory store
+- Per-request cost breakdown (input/output/cache tokens)
+- New providers: DeepSeek, Groq, Together AI, Perplexity
+- New Claude models: claude-fable-5, opus-4-8, opus-4-7
+- Decoupled Routerly model ID from upstream API model name
+- Built-in update checker (polls GitHub Releases every 24h)
+- Dynamic update channels from GitHub Releases
+- CLI: `routerly update check/channel/run`
+- Dashboard: Software Update section, Help & Support page
+- Opt-in anonymous telemetry
+- New API: `/api/system/info` (public), `/api/system/update-check`, `/api/system/update`, `/api/system/releases`
+- Dashboard UX: searchable policy editor, usage pagination, alphabetical models
+
+### Bug fixes
+- Fixed `/api/system/info` accidentally protected by JWT middleware
+- Fixed Qwen3 thinking-only response in Ollama adapter
+- Fixed `reasoning_effort` forwarded to non-o-series models
+- Upgraded Fastify v5, Vite v6, Vitest v4, Commander v14, Zod v4, lucide-react
+- Security hardening
+
+### Release prep (this PR)
+- vitest.config.ts: loadEnv moved to vite (vitest 4.x compat)
+- tsconfig.base.json: Node16 -> NodeNext (import attributes support)
+- shared JSON imports: with { type: 'json' } (Node 22+/25+ required)
+- .dockerignore: added **/*.tsbuildinfo (Docker incremental build fix)
+- CHANGELOG.md added
+- cost/calculator.test.ts: 8 new unit tests
+
+### Tests
+93 passing (11 cli + 54 service + 28 E2E). Docker: build, health, setup, auth, models all verified.
+
+### Breaking changes
+None. OpenAI and Anthropic wire formats unchanged.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+PRBODY
+
+gh pr create \
+  --repo "${REPO}" \
+  --base main \
+  --head develop \
+  --title "release: Routerly 0.2.0" \
+  --body-file "${PR_BODY_FILE}"
+rm -f "${PR_BODY_FILE}"
+
+echo ""
+echo "→ Attendi che la PR sia approvata e mergiata in main, poi premi ENTER."
+read -r -p "ENTER per continuare..."
+
+# Step 4: Checkout main
+echo "→ Step 4: Checkout main"
+git checkout main
+git pull origin main
+
+# Step 5: Ricrea tag v0.2.0 su main HEAD
+echo "→ Step 5: Ricrea tag ${TAG}"
+git tag -d "${TAG}" 2>/dev/null || true
+git push origin --delete "${TAG}" 2>/dev/null || true
+git tag -a "${TAG}" -m "Routerly ${TAG}"
+git push origin "${TAG}"
+
+# Step 6: Aggiorna GitHub Release
+echo "→ Step 6: Aggiorna GitHub Release"
+NOTES_FILE="$(mktemp)"
+awk '/^## \[0\.2\.0\]/{found=1} found && /^## \[0\.1\./{exit} found{print}' CHANGELOG.md > "${NOTES_FILE}"
+gh release edit "${TAG}" \
+  --repo "${REPO}" \
+  --title "Routerly ${TAG}" \
+  --notes-file "${NOTES_FILE}"
+rm -f "${NOTES_FILE}"
+
+# Step 7: Docker multiarch build e push
+echo "→ Step 7: Docker build multiarch e push"
+docker buildx create --use --name routerly-builder 2>/dev/null || docker buildx use routerly-builder
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --tag "${DOCKER_IMAGE}:${VERSION}" \
+  --tag "${DOCKER_IMAGE}:latest" \
+  --push \
+  .
+
+echo ""
+echo "=== ${TAG} rilasciato ==="
+echo "  GitHub: https://github.com/${REPO}/releases/tag/${TAG}"
+echo "  Docker: https://hub.docker.com/r/${DOCKER_IMAGE}/tags"
+echo ""
+echo "→ Verifica docs: la versione default Docusaurus deve puntare a 0.2.0"

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -344,16 +344,16 @@ describe.skipIf(!TOKEN || !ADMIN_PASSWORD)('E2E · Management API', () => {
   // ── POST /api/system/update — auth guards ────────────────────────────────
 
   describe('POST /api/system/update', () => {
-    it('returns 403 when called without auth', async () => {
+    it('returns 401 when called without auth', async () => {
       const res = await post('/api/system/update', {})
-      expect(res.status).toBe(403)
+      expect(res.status).toBe(401)
       const body = await res.json() as Record<string, unknown>
       expect(typeof body['error']).toBe('string')
     })
 
-    it('returns 403 when called with a project token (non-admin)', async () => {
+    it('returns 401 when called with a project token (not a dashboard session)', async () => {
       const res = await post('/api/system/update', {}, auth(TOKEN!))
-      expect(res.status).toBe(403)
+      expect(res.status).toBe(401)
     })
   })
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": [
       "ES2022"
     ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig, loadEnv } from 'vitest/config'
+import { defineConfig } from 'vitest/config'
+import { loadEnv } from 'vite'
 
 export default defineConfig(({ mode }) => {
   // Load .env if present — provides ROUTERLY_TEST_TOKEN and other E2E credentials


### PR DESCRIPTION
## Release prep fixes for 0.2.0

### Changes

- **vitest.config.ts**: `loadEnv` moved from `vitest/config` → `vite` (removed in vitest 4.x)
- **api.ts**: `/api/system/info` added to JWT middleware whitelist (was accidentally protected)
- **e2e.test.ts**: `POST /api/system/update` assertions updated 403 → 401 (correct HTTP semantics)
- **shared JSON imports**: added `with { type: 'json' }` — required by Node 22+/25+
- **tsconfig.base.json**: `Node16` → `NodeNext` (enables import attributes)
- **.dockerignore**: added `**/*.tsbuildinfo` — prevents stale incremental cache from breaking Docker builds
- **CHANGELOG.md**: full 0.2.0 release notes added
- **cost/calculator.test.ts**: 8 new unit tests for `calculateCost`
- **scripts/release-0.2.0.sh**: release automation script
- **ai/learnings**: captured 3 lessons (vitest import, Node JSON imports, JWT whitelist)

### Tests
93 passing (11 cli + 54 service + 28 E2E). Docker image verified: build ✓, health ✓, setup ✓, auth ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)