### PR TITLE
docs(config): set 0.2.0 as default docusaurus version

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -45,15 +45,15 @@ const config: Config = {
           routeBasePath: '/',
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/Inebrio/Routerly/edit/main/',
-          lastVersion: '0.1.5',
+          lastVersion: 'current',
           versions: {
-            '0.1.5': {
-              label: '0.1.5 (current)',
-              badge: true,
-            },
             current: {
               label: '0.2.0',
               badge: false,
+            },
+            '0.1.5': {
+              label: '0.1.5',
+              badge: true,
             },
           },
         },


### PR DESCRIPTION
Sets `lastVersion: 'current'` so the docs default to 0.2.0 (the `docs/` directory) instead of the 0.1.5 versioned snapshot. Removes '(current)' suffix from the 0.1.5 label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)