### PR TITLE
fix(openai): strip input field before forwarding to chat completions api

### DIFF
--- a/packages/service/src/providers/openai.test.ts
+++ b/packages/service/src/providers/openai.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { OpenAIAdapter } from './openai.js';
+import type { ChatCompletionRequest, ModelConfig } from '@routerly/shared';
+
+const create = vi.hoisted(() => vi.fn());
+
+vi.mock('openai', () => {
+  class OpenAIMock {
+    chat = { completions: { create } };
+  }
+  return { default: OpenAIMock };
+});
+
+afterEach(() => vi.clearAllMocks());
+
+function makeModel(overrides: Partial<ModelConfig> = {}): ModelConfig {
+  return {
+    id: 'openai/gpt-4o',
+    name: 'GPT-4o',
+    provider: 'openai',
+    endpoint: 'https://api.openai.com/v1',
+    apiKey: 'sk-test',
+    cost: { inputPerMillion: 5, outputPerMillion: 15 },
+    ...overrides,
+  };
+}
+
+function makeResponse() {
+  return {
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    created: 1700000000,
+    model: 'gpt-4o',
+    choices: [{ index: 0, message: { role: 'assistant', content: 'Hi' }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+  };
+}
+
+describe('OpenAIAdapter.chatCompletion', () => {
+  it('strips the `input` field before forwarding to Chat Completions API', async () => {
+    create.mockResolvedValue(makeResponse());
+
+    const adapter = new OpenAIAdapter();
+    const request: ChatCompletionRequest = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello' }],
+      input: [{ role: 'user', content: 'Hello' }], // simulate /v1/responses leak
+    };
+
+    await adapter.chatCompletion(request, makeModel());
+
+    const calledWith = create.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(calledWith).not.toHaveProperty('input');
+    expect(calledWith).toHaveProperty('messages');
+  });
+
+  it('strips `stream` before forwarding (forces stream: false for non-streaming call)', async () => {
+    create.mockResolvedValue(makeResponse());
+
+    const adapter = new OpenAIAdapter();
+    await adapter.chatCompletion(
+      { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hi' }], stream: true },
+      makeModel(),
+    );
+
+    const calledWith = create.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(calledWith).toHaveProperty('stream', false);
+  });
+
+  it('normalises max_tokens → max_completion_tokens', async () => {
+    create.mockResolvedValue(makeResponse());
+
+    const adapter = new OpenAIAdapter();
+    await adapter.chatCompletion(
+      { model: 'gpt-4o', messages: [{ role: 'user', content: 'Hi' }], max_tokens: 512 },
+      makeModel(),
+    );
+
+    const calledWith = create.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(calledWith).not.toHaveProperty('max_tokens');
+    expect(calledWith).toHaveProperty('max_completion_tokens', 512);
+  });
+
+  it('strips reasoning params for non-o-series models', async () => {
+    create.mockResolvedValue(makeResponse());
+
+    const adapter = new OpenAIAdapter();
+    await adapter.chatCompletion(
+      {
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hi' }],
+        reasoning_effort: 'high',
+        reasoning_summary: 'auto',
+      } as ChatCompletionRequest,
+      makeModel(),
+    );
+
+    const calledWith = create.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(calledWith).not.toHaveProperty('reasoning_effort');
+    expect(calledWith).not.toHaveProperty('reasoning_summary');
+  });
+});

--- a/packages/service/src/providers/openai.ts
+++ b/packages/service/src/providers/openai.ts
@@ -45,13 +45,13 @@ export class OpenAIAdapter implements ProviderAdapter {
 
   // Strip reasoning-model-only params when forwarding to non-o-series models.
   private normalizeForModel(req: ChatCompletionRequest, upstreamModel: string): Record<string, unknown> {
-    const { stream: _stream, ...normalized } = this.normalizeTokenLimit(req);
+    const { stream: _stream, input: _input, ...normalized } = this.normalizeTokenLimit(req) as Record<string, unknown>;
     if (!this.isReasoningModel(upstreamModel)) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { reasoning_effort, reasoning_summary, ...safe } = normalized as Record<string, unknown>;
+      const { reasoning_effort, reasoning_summary, ...safe } = normalized;
       return safe;
     }
-    return normalized as Record<string, unknown>;
+    return normalized;
   }
 
   async chatCompletion(

--- a/packages/service/src/routes/openai.ts
+++ b/packages/service/src/routes/openai.ts
@@ -69,6 +69,7 @@ export const openaiRoutes: FastifyPluginAsync = async (fastify) => {
       if (body.input && !body.messages) {
         body.messages = body.input;
       }
+      delete body.input;
       if (body.max_tokens !== undefined) {
         body.max_output_tokens = body.max_tokens;
         delete body.max_tokens;

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -45,15 +45,15 @@ const config: Config = {
           routeBasePath: '/',
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/Inebrio/Routerly/edit/main/',
-          lastVersion: '0.1.5',
+          lastVersion: 'current',
           versions: {
-            '0.1.5': {
-              label: '0.1.5 (current)',
-              badge: true,
-            },
             current: {
               label: '0.2.0',
               badge: false,
+            },
+            '0.1.5': {
+              label: '0.1.5',
+              badge: true,
             },
           },
         },


### PR DESCRIPTION
## Summary

- **Bug**: `/v1/responses` handler copied `input` → `messages` but never deleted `body.input`. The field leaked into the upstream OpenAI Chat Completions request causing `400 Unknown parameter: 'input'` on every `gpt-5.2` call.
- **Fix 1**: `routes/openai.ts` — `delete body.input` after copying to `messages`
- **Fix 2**: `providers/openai.ts` — `normalizeForModel` now explicitly strips `input` as safety net for direct `/v1/chat/completions` clients that include the field
- **Tests**: new `providers/openai.test.ts` with 4 regression cases

## Root cause details

The fallback routing was masking the error (gpt-5.2 fails → Claude takes over → `outcome: success`), so it only surfaced in the trace logs as repeated `model:error` entries.

## Test plan

- [x] `npm test --workspace=packages/service` — 58/58 passed
- [x] `npm run typecheck` — clean
- [x] Verified endpoint via curl with live data: 60 records, 11 errors now resolved after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)