### PR TITLE
ci(docker): add workflow_dispatch for manual docker rebuild

### DIFF
--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -1,0 +1,54 @@
+name: Docker Rebuild
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to build (e.g. v0.2.0). Defaults to version in package.json.'
+        required: false
+
+concurrency: docker-rebuild
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract version
+        id: meta
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION="v$(node -p "require('./packages/service/package.json').version")"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            inebrio/routerly:latest
+            inebrio/routerly:${{ steps.meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds `docker-rebuild.yml` workflow with `workflow_dispatch` trigger
- Needed for hotfix releases that don't bump the version (no changeset) — the `release.yml` Docker job is skipped when changesets are pending
- Accepts an optional `version` input (defaults to `package.json` version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)