### PR TITLE
fix(telemetry): fire install/upgrade ping on startup when version changes

### DIFF
--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -362,6 +362,7 @@ export type EmailConfig = SmtpChannelConfig | SesChannelConfig | SendGridChannel
 export interface TelemetryConfig {
   enabled: boolean;
   installId: string;
+  lastPingedVersion?: string;
 }
 
 export interface Settings {

--- a/packages/service/src/routes/api.ts
+++ b/packages/service/src/routes/api.ts
@@ -907,7 +907,13 @@ export const apiRoutes: FastifyPluginAsync = async (fastify) => {
       const wasEnabled = current.telemetry?.enabled === true;
       if (telemetryPatch.enabled) {
         const installId = current.telemetry?.installId || randomUUID();
-        updated.telemetry = { enabled: true, installId };
+        updated.telemetry = {
+          enabled: true,
+          installId,
+          ...(current.telemetry?.lastPingedVersion !== undefined
+            ? { lastPingedVersion: current.telemetry.lastPingedVersion }
+            : {}),
+        };
         if (!wasEnabled) pingTelemetry(installId, 'install');
       } else {
         updated.telemetry = { enabled: false, installId: current.telemetry?.installId ?? '' };

--- a/packages/service/src/server.telemetry.test.ts
+++ b/packages/service/src/server.telemetry.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const _dir = dirname(fileURLToPath(import.meta.url));
+const { version: CURRENT_VERSION } = JSON.parse(
+  readFileSync(join(_dir, '../package.json'), 'utf-8'),
+) as { version: string };
+
+// ── Hoist mock factories before any import ───────────────────────────────────
+
+const { mockPing, mockReadConfig, mockWriteConfig, mockInitConfigDirs, mockLoadSecret } =
+  vi.hoisted(() => ({
+    mockPing: vi.fn(),
+    mockReadConfig: vi.fn(),
+    mockWriteConfig: vi.fn().mockResolvedValue(undefined),
+    mockInitConfigDirs: vi.fn().mockResolvedValue(undefined),
+    mockLoadSecret: vi.fn().mockResolvedValue(undefined),
+  }));
+
+vi.mock('./telemetry.js', () => ({ pingTelemetry: mockPing }));
+vi.mock('./config/loader.js', () => ({
+  initConfigDirs: mockInitConfigDirs,
+  readConfig: mockReadConfig,
+  writeConfig: mockWriteConfig,
+}));
+vi.mock('./plugins/jwt.js', () => ({ loadSecret: mockLoadSecret }));
+vi.mock('./update-checker.js', () => ({ updateChecker: { start: vi.fn() } }));
+
+vi.mock('fastify', () => ({
+  default: vi.fn(() => ({
+    register: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn(),
+    listen: vi.fn().mockResolvedValue(undefined),
+    log: { warn: vi.fn(), error: vi.fn() },
+    setNotFoundHandler: vi.fn(),
+  })),
+}));
+vi.mock('@fastify/cors', () => ({ default: vi.fn() }));
+vi.mock('@fastify/static', () => ({ default: vi.fn() }));
+vi.mock('./plugins/auth.js', () => ({ default: vi.fn() }));
+vi.mock('./routes/api.js', () => ({ apiRoutes: vi.fn() }));
+vi.mock('./routes/openai.js', () => ({ openaiRoutes: vi.fn() }));
+vi.mock('./routes/anthropic.js', () => ({ anthropicRoutes: vi.fn() }));
+
+import { startServer } from './server.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSettings(telemetry?: { enabled: boolean; installId: string; lastPingedVersion?: string }) {
+  return {
+    port: 3000,
+    host: '0.0.0.0',
+    dashboardEnabled: false,
+    defaultTimeoutMs: 30000,
+    logLevel: 'info' as const,
+    channel: 'latest',
+    ...(telemetry !== undefined ? { telemetry } : {}),
+  };
+}
+
+afterEach(() => vi.clearAllMocks());
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('startServer() startup telemetry', () => {
+  it('does not ping when telemetry is absent (user not yet asked)', async () => {
+    mockReadConfig.mockResolvedValue(makeSettings());
+
+    await startServer();
+
+    expect(mockPing).not.toHaveBeenCalled();
+    expect(mockWriteConfig).not.toHaveBeenCalled();
+  });
+
+  it('does not ping when telemetry is disabled', async () => {
+    mockReadConfig.mockResolvedValue(makeSettings({ enabled: false, installId: 'id-1' }));
+
+    await startServer();
+
+    expect(mockPing).not.toHaveBeenCalled();
+    expect(mockWriteConfig).not.toHaveBeenCalled();
+  });
+
+  it('fires "install" when lastPingedVersion is absent', async () => {
+    mockReadConfig.mockResolvedValue(makeSettings({ enabled: true, installId: 'uuid-abc' }));
+
+    await startServer();
+
+    expect(mockPing).toHaveBeenCalledWith('uuid-abc', 'install');
+    expect(mockWriteConfig).toHaveBeenCalledWith(
+      'settings',
+      expect.objectContaining({
+        telemetry: expect.objectContaining({ lastPingedVersion: CURRENT_VERSION }),
+      }),
+    );
+  });
+
+  it('fires "upgrade" when lastPingedVersion differs from current version', async () => {
+    mockReadConfig.mockResolvedValue(
+      makeSettings({ enabled: true, installId: 'uuid-def', lastPingedVersion: '0.0.1' }),
+    );
+
+    await startServer();
+
+    expect(mockPing).toHaveBeenCalledWith('uuid-def', 'upgrade');
+    expect(mockWriteConfig).toHaveBeenCalledWith(
+      'settings',
+      expect.objectContaining({
+        telemetry: expect.objectContaining({ lastPingedVersion: CURRENT_VERSION }),
+      }),
+    );
+  });
+
+  it('does not ping when lastPingedVersion already matches current version', async () => {
+    mockReadConfig.mockResolvedValue(
+      makeSettings({ enabled: true, installId: 'uuid-ghi', lastPingedVersion: CURRENT_VERSION }),
+    );
+
+    await startServer();
+
+    expect(mockPing).not.toHaveBeenCalled();
+    expect(mockWriteConfig).not.toHaveBeenCalled();
+  });
+});

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -9,7 +9,8 @@ import { loadSecret } from './plugins/jwt.js';
 import { openaiRoutes } from './routes/openai.js';
 import { anthropicRoutes } from './routes/anthropic.js';
 import { apiRoutes } from './routes/api.js';
-import { initConfigDirs, readConfig } from './config/loader.js';
+import { initConfigDirs, readConfig, writeConfig } from './config/loader.js';
+import { pingTelemetry } from './telemetry.js';
 import { updateChecker } from './update-checker.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -86,6 +87,23 @@ export async function startServer() {
   await initConfigDirs();
   await loadSecret();
   const settings = await readConfig('settings');
+
+  if (settings.telemetry?.enabled === true) {
+    const { installId, lastPingedVersion } = settings.telemetry;
+    const event: 'install' | 'upgrade' | null =
+      !lastPingedVersion ? 'install' :
+      lastPingedVersion !== pkgVersion ? 'upgrade' :
+      null;
+
+    if (event !== null) {
+      pingTelemetry(installId, event);
+      await writeConfig('settings', {
+        ...settings,
+        telemetry: { ...settings.telemetry, lastPingedVersion: pkgVersion },
+      });
+    }
+  }
+
   const server = await buildServer();
 
   try {

--- a/packages/service/src/telemetry.ts
+++ b/packages/service/src/telemetry.ts
@@ -30,6 +30,8 @@ export function pingTelemetry(installId: string, event: TelemetryEvent): void {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
       signal: AbortSignal.timeout(3000),
-    }).catch(() => { /* fire-and-forget: network errors, timeouts, server down */ });
+    })
+      .then(res => console.log(`[telemetry] ${event} sent → ${res.status}`))
+      .catch(err => console.log(`[telemetry] ${event} failed → ${(err as Error).message}`));
   } catch { /* never propagate to the caller */ }
 }

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -309,6 +309,8 @@ export interface TelemetryConfig {
   enabled: boolean;
   /** Random UUID generated once at opt-in time, never changes */
   installId: string;
+  /** Version that last fired a telemetry ping — absent means not yet tracked */
+  lastPingedVersion?: string;
 }
 
 export interface Settings {


### PR DESCRIPTION
## Summary

- Add `lastPingedVersion` to `TelemetryConfig` to track which version last sent a telemetry ping
- On service startup, fire `'install'` if `lastPingedVersion` is absent, `'upgrade'` if it differs from current version — fixes the case where upgrading Docker with telemetry already enabled produced no ping
- Preserve `lastPingedVersion` when toggling telemetry via the settings API
- Add console.log for ping result to aid debugging
- Fix: validate.ts regex in telemetry backend was rejecting UUID installIds (hyphens not allowed)

## Test plan

- [ ] `npm run typecheck` — all packages pass
- [ ] `npm test --workspace=packages/service` — 63 tests pass (5 new scenarios in `server.telemetry.test.ts`)
- [ ] Manual: set `lastPingedVersion: "0.1.0"` in settings.json, restart service → log shows `[telemetry] upgrade sent → 200`
- [ ] Manual: remove `lastPingedVersion`, restart service → log shows `[telemetry] install sent → 200`
- [ ] Manual: same version → no ping, no write

🤖 Generated with [Claude Code](https://claude.com/claude-code)