### PR TITLE
fix: update checker rolling channels + CI tag push refspec

### DIFF
--- a/.github/workflows/promote-develop.yml
+++ b/.github/workflows/promote-develop.yml
@@ -42,7 +42,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -f develop
-          git push origin develop --force
+          git push origin refs/tags/develop:refs/tags/develop --force
 
       - name: Delete existing develop release (if any)
         env:

--- a/packages/service/src/update-checker.test.ts
+++ b/packages/service/src/update-checker.test.ts
@@ -134,13 +134,23 @@ describe('UpdateChecker.check()', () => {
     expect(result.available).toBe(false);
   });
 
-  it('returns available=false for non-semver tag names (parseSemver returns null)', async () => {
-    stubGithubOk({ tag_name: 'not-a-version', html_url: '', prerelease: false });
+  it('returns available=false for non-semver tag names with no version in name', async () => {
+    stubGithubOk({ tag_name: 'not-a-version', name: '', html_url: '', prerelease: false });
 
     checker.start('0.1.5', 'latest');
     const result = await checker.check();
 
     expect(result.available).toBe(false);
+  });
+
+  it('extracts version from release name for rolling channels (develop/stable)', async () => {
+    stubGithubOk({ tag_name: 'develop', name: 'Routerly 0.3.0 (develop channel)', html_url: 'https://example.com', prerelease: true });
+
+    checker.start('0.2.0', 'develop');
+    const result = await checker.check();
+
+    expect(result.available).toBe(true);
+    expect(result.latestVersion).toBe('0.3.0');
   });
 
   it('keeps existing cached result when a subsequent check fails', async () => {

--- a/packages/service/src/update-checker.ts
+++ b/packages/service/src/update-checker.ts
@@ -40,6 +40,7 @@ function isNewer(candidate: string, current: string): boolean {
 
 interface GithubRelease {
   tag_name: string;
+  name: string;
   html_url: string;
   prerelease: boolean;
   draft: boolean;
@@ -150,9 +151,12 @@ export class UpdateChecker {
     const channel = this._channel;
     try {
       const release = await fetchRelease(channel);
-      const latestVersion = release.tag_name.startsWith('v')
-        ? release.tag_name.slice(1)
-        : release.tag_name;
+      const rawTag = release.tag_name.startsWith('v') ? release.tag_name.slice(1) : release.tag_name;
+      // For rolling channels (develop, stable) the tag_name is not semver.
+      // Extract version from the release title, e.g. "Routerly 0.3.0 (develop channel)".
+      const latestVersion = parseSemver(rawTag)
+        ? rawTag
+        : (release.name?.match(/(\d+\.\d+\.\d+)/)?.[1] ?? rawTag);
 
       const result: UpdateInfo = {
         available: isNewer(latestVersion, this._currentVersion),


### PR DESCRIPTION
## Changes

- `fix(update-checker)`: extract semver from release name for rolling channels (develop/stable) — fixes #119
- `fix(ci)`: push develop tag by explicit refspec to avoid ambiguity when branch and tag share the name `develop`

## Quality gates
- [x] Tests green (30 passing)
- [x] Fix verified and tested (unit tests added for rolling channel extraction)
- [x] Already shipped in Docker `:develop` / `:0.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)