### PR TITLE
fix(catalog): use upstream timestamp from index.json as content-change date

### DIFF
--- a/packages/service/src/catalog/fetcher.test.ts
+++ b/packages/service/src/catalog/fetcher.test.ts
@@ -327,7 +327,8 @@ describe('CatalogFetcher', () => {
       const [firstStatus] = fetcher.getStatus();
       const firstUpdatedAt = firstStatus!.updatedAt;
       const firstLastChecked = firstStatus!.lastChecked;
-      expect(firstUpdatedAt).toBe(firstLastChecked); // first download: both set to same checkedAt
+      expect(firstUpdatedAt).toBe(updateTs); // updatedAt = upstream timestamp, not local check time
+      expect(firstUpdatedAt).not.toBe(firstLastChecked);
 
       vi.advanceTimersByTime(7 * 60 * 60 * 1000);
       await fetcher.get('0.2.0');

--- a/packages/service/src/catalog/fetcher.ts
+++ b/packages/service/src/catalog/fetcher.ts
@@ -118,7 +118,7 @@ class CatalogFetcher {
         }
         this.repoStatus.set(repo.url, {
           url: repo.url, enabled: true, resolvedFile: result.resolvedFile,
-          updatedAt: result.changed ? checkedAt : (prev?.updatedAt ?? null),
+          updatedAt: result.changed ? (result.upstreamMeta?.upstreamUpdatedAt ?? checkedAt) : (prev?.updatedAt ?? null),
           lastChecked: checkedAt, error: null,
         });
       } catch (err) {


### PR DESCRIPTION
## Problem

`updatedAt` was set to local `checkedAt` time on every download, making it identical to `lastChecked`. Dashboard showed the same date for both columns.

## Fix

Use `upstreamMeta.upstreamUpdatedAt` from `index.json` as `updatedAt` when available. This is the remote catalog's own modification timestamp — the actual date the content changed, not when Routerly checked it.

Logic:
- index signals change (`upstreamUpdatedAt` differs) → download, set `updatedAt` = upstream timestamp
- no change → keep existing `updatedAt`
- always update `lastChecked`

## Tests

18/18 passing. Updated assertion to expect upstream timestamp (not `checkedAt`) on first download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)