### PR TITLE
fix(catalog): last repo in list overrides earlier ones on key conflict

### DIFF
--- a/packages/service/src/catalog/fetcher.test.ts
+++ b/packages/service/src/catalog/fetcher.test.ts
@@ -181,14 +181,12 @@ describe('CatalogFetcher', () => {
   });
 
   describe('multi-repo merging', () => {
-    it('first repo wins when keys overlap', async () => {
-      // Implementation reverses repos before iterating, then Object.assign — so repo[0] is applied last and wins
+    it('last repo wins when keys overlap', async () => {
       const catalog1 = JSON.stringify({ openai: { endpoint: 'https://custom.example.com/v1', models: [] } });
       const catalog2 = JSON.stringify({ openai: { endpoint: 'https://api.openai.com/v1', models: [] } });
 
       vi.stubGlobal('fetch', async (url: string) => {
         if (url.endsWith('index.json')) return { ok: false, status: 404, json: async () => ({}), text: async () => '' };
-        // Route by host
         const body = url.includes('repo1') ? catalog1 : catalog2;
         return { ok: true, status: 200, json: async () => JSON.parse(body), text: async () => body };
       });
@@ -199,8 +197,8 @@ describe('CatalogFetcher', () => {
         { url: 'https://repo2.example.com/', enabled: true },
       ]);
       const result = await fetcher.get('0.2.0');
-      // First repo (index 0) wins because it is applied last (reversed iteration + Object.assign)
-      expect((result as any).openai.endpoint).toBe('https://custom.example.com/v1');
+      // Last repo (index 1) wins — it is applied last via Object.assign
+      expect((result as any).openai.endpoint).toBe('https://api.openai.com/v1');
     });
 
     it('skips disabled repos', async () => {

--- a/packages/service/src/catalog/fetcher.ts
+++ b/packages/service/src/catalog/fetcher.ts
@@ -127,9 +127,9 @@ class CatalogFetcher {
       }
     }
 
-    // Merge in reverse order so first repo wins
+    // Last repo in the list overrides earlier ones
     const merged: ProviderCatalog = {};
-    for (const repo of [...this.repos].reverse()) {
+    for (const repo of this.repos) {
       const cat = this.repoCatalog.get(repo.url);
       if (cat && repo.enabled) Object.assign(merged, cat);
     }


### PR DESCRIPTION
## Change

Multi-repo merge order was reversed: last repo in the configured list now overrides earlier ones, consistent with standard override semantics (bottom entry wins).

**Before:** first repo (index 0) won via reversed iteration + `Object.assign`.
**After:** last repo (highest index) wins via forward iteration + `Object.assign`.

## Tests

18/18 passing. Updated the merge-order assertion to reflect new behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)