### PR TITLE
fix(release-channels): land the 0.4.0 version bump

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -23,7 +23,7 @@ export default {
     }],
     ['@semantic-release/exec', {
       prepareCmd:
-        'npm version ${nextRelease.version} --workspaces --include-workspace-root --no-git-tag-version --ignore-scripts' +
+        'npm version ${nextRelease.version} --allow-same-version --workspaces --include-workspace-root --no-git-tag-version --ignore-scripts' +
         ' && node scripts/sync-module-versions.mjs' +
         ' && node scripts/sync-module-versions.mjs --check',
       publishCmd:


### PR DESCRIPTION
Second feat commit on top of v0.3.0 (published by the previous run) to trigger the 0.3.0 -> 0.4.0 minor bump, plus a fix for the prepareCmd npm version collision that blocked it.

Refs release-channels feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)