### PR TITLE
fix(mcp): backfill routerIds on pre-existing users to stop /mcp crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ A Passthrough router's real target models now route, authenticate, and meter exa
 - Passthrough router names are now unique only among other Passthroughs, not across every router kind — a Passthrough can share its name with an existing Router or Orchestrator (it is reached by slug, never by name), while Router and Orchestrator names stay unique among themselves as before.
 - Dashboard: creating a Passthrough router now redirects straight to its General tab, instead of surfacing a spurious "Unsaved Changes" confirmation on the create form's own success redirect.
 - Dashboard: an Orchestrator's Routing tab no longer shows the "Target Models" section — that model picker had no `kind`-based guard and let a model be added to an Orchestrator, which only ever routes to candidate Routers (configured on its own Orchestrator tab), never to models directly.
+- `POST /mcp` no longer 500s ("Cannot read properties of undefined (reading 'includes')") for any user account created before `routerIds` was added to `UserConfig` — a startup migration now backfills `routerIds: []` on stored users missing it, and `accessibleRouters()` no longer assumes the field is present on every user record on disk.
 
 ### Breaking changes
 

--- a/packages/service/src/modules/config/index.test.ts
+++ b/packages/service/src/modules/config/index.test.ts
@@ -11,6 +11,7 @@ vi.mock('./migrate.js', () => ({
   migrateNotificationChannelScope: vi.fn(async () => 0),
   migrateOrchestratorCandidateOrder: vi.fn(async () => 0),
   migratePassthroughPseudoModel: vi.fn(async () => 0),
+  migrateUserRouterIds: vi.fn(async () => 0),
 }))
 vi.mock('./migrate-connections.js', () => ({
   migrateModelsToConnections: vi.fn(async () => ({ connections: 0, instances: 0 })),

--- a/packages/service/src/modules/config/index.ts
+++ b/packages/service/src/modules/config/index.ts
@@ -10,6 +10,7 @@ import {
   migrateNotificationChannelScope,
   migrateOrchestratorCandidateOrder,
   migratePassthroughPseudoModel,
+  migrateUserRouterIds,
 } from './migrate.js'
 
 /**
@@ -73,6 +74,11 @@ export const configModule = defineModule({
     if (passthroughMigrated > 0) {
       // eslint-disable-next-line no-console
       console.log(`[startup] migrated ${passthroughMigrated} passthrough router(s) with a pass-through entry`)
+    }
+    const userRouterIdsMigrated = await migrateUserRouterIds()
+    if (userRouterIdsMigrated > 0) {
+      // eslint-disable-next-line no-console
+      console.log(`[startup] backfilled routerIds on ${userRouterIdsMigrated} user(s) missing it`)
     }
     // migrateUsageToNdjson() deliberately does NOT run here: this migrate()
     // is wrapped by the kernel in a best-effort try/catch that logs and

--- a/packages/service/src/modules/config/migrate.test.ts
+++ b/packages/service/src/modules/config/migrate.test.ts
@@ -32,6 +32,7 @@ import {
   migrateUsageToNdjson,
   migrateOrchestratorCandidateOrder,
   migratePassthroughPseudoModel,
+  migrateUserRouterIds,
 } from './migrate.js';
 import { PASSTHROUGH_MODEL_ID } from '@routerly/shared';
 import { readConfig, writeConfig } from './loader.js';
@@ -1127,6 +1128,35 @@ describe('migrateOrchestratorCandidateOrder', () => {
     mockReadConfig.mockResolvedValueOnce(migrated as any);
     const count2 = await migrateOrchestratorCandidateOrder();
     expect(count2).toBe(0);
+    expect(mockWriteConfig).not.toHaveBeenCalled();
+  });
+});
+
+// ─── migrateUserRouterIds (RTR-01: backfill routerIds on pre-existing users) ─
+
+describe('migrateUserRouterIds', () => {
+  it('backfills routerIds: [] on users missing the field, writes users back', async () => {
+    mockReadConfig.mockResolvedValue([
+      { id: 'u1', email: 'a@a.com', roleId: 'admin' },
+      { id: 'u2', email: 'b@b.com', roleId: 'member', routerIds: ['p1'] },
+    ] as any);
+
+    const count = await migrateUserRouterIds();
+
+    expect(count).toBe(1);
+    const saved = mockWriteConfig.mock.calls[0]![1] as any[];
+    expect(saved[0].routerIds).toEqual([]);
+    expect(saved[1].routerIds).toEqual(['p1']);
+  });
+
+  it('EC1: every user already has routerIds → no-op, no write', async () => {
+    mockReadConfig.mockResolvedValue([
+      { id: 'u1', email: 'a@a.com', roleId: 'admin', routerIds: [] },
+    ] as any);
+
+    const count = await migrateUserRouterIds();
+
+    expect(count).toBe(0);
     expect(mockWriteConfig).not.toHaveBeenCalled();
   });
 });

--- a/packages/service/src/modules/config/migrate.ts
+++ b/packages/service/src/modules/config/migrate.ts
@@ -137,6 +137,27 @@ export async function migrateNotificationChannelScope(): Promise<number> {
   return count;
 }
 
+/**
+ * Backfills `routerIds: []` on any stored user missing the field (RTR-01
+ * added `routerIds` to `UserConfig` after some installs already had users on
+ * disk). Without this, `accessibleRouters()`'s `user.routerIds.includes(...)`
+ * throws on that user's very first MCP/API call — `routerIds` is typed
+ * required, but nothing ever wrote it onto pre-existing records. Idempotent:
+ * a user that already has the field is left untouched. Returns the number of
+ * users rewritten.
+ */
+export async function migrateUserRouterIds(): Promise<number> {
+  const users = await readConfig('users') as unknown as Array<Record<string, unknown>>;
+  let count = 0;
+  const updated = users.map((user) => {
+    if (Array.isArray(user['routerIds'])) return user;
+    count++;
+    return { ...user, routerIds: [] };
+  });
+  if (count > 0) await writeConfig('users', updated as unknown as Awaited<ReturnType<typeof readConfig<'users'>>>);
+  return count;
+}
+
 // Legacy shapes (only what we need to detect/convert — not exported to callers)
 interface LegacyGuardrailConfig {
   action?: string;

--- a/packages/service/src/modules/mcp/tokens.ts
+++ b/packages/service/src/modules/mcp/tokens.ts
@@ -69,7 +69,7 @@ export async function resolveUserPermissions(user: UserConfig): Promise<Permissi
 export async function accessibleRouters(user: UserConfig): Promise<RouterConfig[]> {
   const routers = await readConfig('routers')
   const scoped = routers.filter(
-    (p) => user.routerIds.includes(p.id) || p.members?.some((m) => m.userId === user.id),
+    (p) => (user.routerIds ?? []).includes(p.id) || p.members?.some((m) => m.userId === user.id),
   )
   return scoped.length > 0 ? scoped : routers
 }


### PR DESCRIPTION
## Root cause

Reported: Codex (on user's own LAN) connecting to Routerly's custom MCP connector hung indefinitely ("carica all'infinito"). Direct `POST /mcp` test against the reporting instance with a real token returned an immediate 500:

```
{"statusCode":500,"error":"Internal Server Error","message":"Cannot read properties of undefined (reading 'includes')"}
```

`accessibleRouters()` (packages/service/src/modules/mcp/tokens.ts) calls `user.routerIds.includes(p.id)` unguarded. `UserConfig.routerIds` is typed required (`string[]`), but no migration ever backfilled it onto users created before the field existed — so any account predating that field crashes on its very first MCP call. The MCP client (Codex) apparently doesn't surface that 500 to the UI, it just spins.

## Fix

- `migrateUserRouterIds()` — new startup migration (same lazy pattern as the other config migrations in `migrate.ts`), backfills `routerIds: []` on any stored user missing it. Wired into `configModule.migrate()`.
- `accessibleRouters()` — defensive `(user.routerIds ?? [])` backstop against the same crash class from any other stale-data path.

## Testing

- New unit tests for `migrateUserRouterIds` (backfill + no-op idempotent case).
- Full service suite: 198 files / 3738 tests pass.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)