### PR TITLE
fix(reverse-proxy): reload live oauth credential before anthropic passthrough forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ A Passthrough router's real target models now route, authenticate, and meter exa
 - Dashboard: creating a Passthrough router now redirects straight to its General tab, instead of surfacing a spurious "Unsaved Changes" confirmation on the create form's own success redirect.
 - Dashboard: an Orchestrator's Routing tab no longer shows the "Target Models" section — that model picker had no `kind`-based guard and let a model be added to an Orchestrator, which only ever routes to candidate Routers (configured on its own Orchestrator tab), never to models directly.
 - `POST /mcp` no longer 500s ("Cannot read properties of undefined (reading 'includes')") for any user account created before `routerIds` was added to `UserConfig` — a startup migration now backfills `routerIds: []` on stored users missing it, and `accessibleRouters()` no longer assumes the field is present on every user record on disk.
+- Anthropic OAuth (and Anthropic web) models on the `/v1/messages` passthrough lane no longer fail every request with an immediate auth error. The lane built its forwarding model from the routing candidate list, which never fetches a live token; the decrypted/refreshed OAuth credential was only ever wired into the non-passthrough SDK path. Every OAuth-connected Anthropic request now reloads the live credential right before forwarding, same as the SDK path already did.
 
 ### Breaking changes
 

--- a/packages/service/src/modules/reverse-proxy/lanes/anthropic.test.ts
+++ b/packages/service/src/modules/reverse-proxy/lanes/anthropic.test.ts
@@ -464,6 +464,28 @@ describe('anthropic:upstream', () => {
     expect(ctx.result).toEqual({ kind: 'passthrough' })
   })
 
+  // Regression: listEffectiveModels() (used to build ctx.attempt.model) is a static resolve
+  // with no live token fetch, so a plain anthropic-oauth connection's apiKey field is empty —
+  // forwarding that model verbatim sends `Authorization: Bearer ` and every request 401s.
+  // The lane must reload via loadEffectiveModel() to get the decrypted/refreshed token.
+  it('anthropic-oauth reloads the live (decrypted/refreshed) credential before forwarding', async () => {
+    await seedModels([
+      { ...model, id: 'oauth-a', name: 'oauth-a', provider: 'anthropic-oauth', apiKey: 'live-token-from-connection' },
+    ])
+    const reply: any = { header: vi.fn() }
+    const ctx = {
+      protocol: 'anthropic', reply, traceId: 't1',
+      // Stale/empty apiKey, as listEffectiveModels() would hand back for a real OAuth connection
+      // whose credentials live in oauthEnc/refreshEnc, not apiKey.
+      attempt: { model: { ...model, id: 'oauth-a', provider: 'anthropic-oauth', apiKey: undefined }, candidate },
+      original: { model: 'claude-3-5', messages: [] }, req: {}, log: makeLog(), router: { id: 'p1' },
+    } as unknown as ProxyContext
+    await anthropicUpstream.run(ctx)
+    expect(mockForwardOAuth).toHaveBeenCalledOnce()
+    const forwardedModel = mockForwardOAuth.mock.calls[0]![2]
+    expect(forwardedModel.apiKey).toBe('live-token-from-connection')
+  })
+
   describe('openai-oauth', () => {
     const oauthCtx = (stream: boolean) => ({
       protocol: 'anthropic', traceId: 't-oa',

--- a/packages/service/src/modules/reverse-proxy/lanes/anthropic.ts
+++ b/packages/service/src/modules/reverse-proxy/lanes/anthropic.ts
@@ -7,7 +7,7 @@ import { getProxyPipeline } from '../run.js'
 import { runCandidateLoop } from '../candidate-loop.js'
 import { forwardToRouter } from '../../routing/orchestrate.js'
 import { listEffectiveModels } from '../../provider/list-effective.js'
-import { llmChat, llmStream, BudgetExceededError, upstreamResponseFromError } from '../execute.js'
+import { llmChat, llmStream, loadEffectiveModel, BudgetExceededError, upstreamResponseFromError } from '../execute.js'
 import type { LLMCallContext } from '../execute.js'
 import { traceEgress } from '../helpers.js'
 import { forwardAnthropicOAuth, forwardAnthropicApiKey } from './oauthForward.js'
@@ -76,17 +76,25 @@ export const anthropicUpstream: Processor<ProxyContext> = {
     const endUserId = (body as any).user as string | undefined || undefined
 
     // ── OAuth models: verbatim pass-through with OAuth token (anthropic.ts L221-224). ──
+    // listEffectiveModels() above is a static resolve (no live token fetch) — reload via
+    // loadEffectiveModel() so the OAuth token is decrypted and refreshed if near expiry,
+    // same as llmChat/llmStream already do for the SDK path (execute.ts). Without this the
+    // passthrough forwards `Bearer ` with no/stale token and every request 401s immediately.
     if (model.provider === 'anthropic-oauth') {
       ctx.passthrough = true
-      await forwardAnthropicOAuth(req, reply, model)
+      const liveModel = (await loadEffectiveModel(model.id)) ?? model
+      await forwardAnthropicOAuth(req, reply, liveModel)
       ctx.result = { kind: 'passthrough' }
       return
     }
 
     // ── Anthropic API-key / web models: verbatim pass-through (anthropic.ts L229-232). ──
+    // Same live-credential reload as above: anthropic-web's session key also needs it;
+    // plain anthropic api-key models resolve to the same static value either way.
     if (model.provider === 'anthropic' || model.provider === 'anthropic-web') {
       ctx.passthrough = true
-      await forwardAnthropicApiKey(req, reply, model)
+      const liveModel = (await loadEffectiveModel(model.id)) ?? model
+      await forwardAnthropicApiKey(req, reply, liveModel)
       ctx.result = { kind: 'passthrough' }
       return
     }


### PR DESCRIPTION
## Bug

Every request to an `anthropic-oauth` model (and `anthropic-web`) failed immediately with an auth error. Reported by the user: "ho usato anthropic via oauth e nessun modello sembra rispondere". Confirmed live via `mcp__routerly__get_metrics_snapshot`: all recorded `anthropic-oauth/*` requests were status `error`, 0 tokens, sub-second latency — consistent with an immediate 401, not a timeout.

## Root cause

The anthropic transport lane (`lanes/anthropic.ts`) builds its passthrough candidate model from `listEffectiveModels()`, documented as a "static resolve, no live token fetch" (`provider/list-effective.ts:18`). It then forwards that model verbatim to `forwardAnthropicOAuth`/`forwardAnthropicApiKey` (`lanes/oauthForward.ts`), which uses `model.apiKey` directly as the Bearer token.

The decrypted/refreshed OAuth credential (`resolveAnthropicOAuthCredential`) is only wired into `loadEffectiveModel()` (`execute.ts`), used by the SDK path (`llmChat`/`llmStream`) — which self-heals by re-resolving the model right before the call (`execute.ts:315`). The passthrough lane never goes through `loadEffectiveModel()`, so `model.apiKey` stays whatever `listEffectiveModels()` handed back — empty/stale for a real OAuth connection whose credentials live in `oauthEnc`/`refreshEnc`, not `apiKey`.

## Fix

Reload via `loadEffectiveModel(model.id)` right before forwarding, for both the `anthropic-oauth` and `anthropic`/`anthropic-web` branches — mirroring what the SDK path already does.

## Verification

- Root cause confirmed by direct code reading (not just agent reports): `resolve.ts`, `list-effective.ts`, `execute.ts:176-204`, `anthropic-oauth.ts`, `oauthForward.ts`.
- New regression test: OAuth request forwards the live (decrypted) credential, not the stale one from the static candidate list.
- `tsc --noEmit` clean.
- Full service suite: 198/198 files, 3739/3739 tests passing.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>